### PR TITLE
Migrate build configuration to AGP 9.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,9 +81,6 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.13"
-    }
     packaging {
         jniLibs.pickFirsts.add("**/libc++_shared.so")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.androidApplication) apply false
-    alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.google.service) apply false

--- a/checkout/data/build.gradle.kts
+++ b/checkout/data/build.gradle.kts
@@ -108,5 +108,5 @@ dependencies {
 
     implementation(libs.room.ktx)
     implementation(libs.room.runtime)
-    annotationProcessor(libs.room.compiler)
+    ksp(libs.room.compiler)
 }

--- a/core/presentation/build.gradle.kts
+++ b/core/presentation/build.gradle.kts
@@ -39,9 +39,6 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.13"
-    }
 }
 
 dependencies {

--- a/delivery/data/build.gradle.kts
+++ b/delivery/data/build.gradle.kts
@@ -83,5 +83,5 @@ dependencies {
 
     implementation(libs.room.ktx)
     implementation(libs.room.runtime)
-    annotationProcessor(libs.room.compiler)
+    ksp(libs.room.compiler)
 }

--- a/details/presentation/build.gradle.kts
+++ b/details/presentation/build.gradle.kts
@@ -38,9 +38,6 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.13"
-    }
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Base
-agp = "9.0.0-rc01"
+agp = "9.0.1"
 protobuf = "4.26.1"
 kotlin = "2.3.0"
 kotlinx-coroutines = "1.10.2"
@@ -185,9 +185,7 @@ androidx-exifinterface = { group = "androidx.exifinterface", name = "exifinterfa
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
-kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 firebase-crashlytics-plugin = { id = "com.google.firebase.crashlytics", version.ref = "crashlytics" }

--- a/home/data/build.gradle.kts
+++ b/home/data/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.androidLibrary)
         alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -58,7 +59,7 @@ dependencies {
     implementation(libs.firebase.auth)
     implementation(libs.firebase.firestore)
 
-    annotationProcessor(libs.room.compiler)
+    ksp(libs.room.compiler)
     implementation(libs.room.ktx)
     implementation(libs.room.runtime)
 }

--- a/home/presentation/build.gradle.kts
+++ b/home/presentation/build.gradle.kts
@@ -37,9 +37,6 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.13"
-    }
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"


### PR DESCRIPTION
Remove composeOptions blocks (removed in AGP 9.0 new DSL), remove redundant kotlinAndroid/kotlin-kapt plugin declarations, switch Room compiler from annotationProcessor to ksp, and bump AGP to stable 9.0.1.