### PR TITLE
Fix order preparation sorting/filtering and visually mark past orders

### DIFF
--- a/admin/domain/src/main/java/com/mtdevelopment/admin/domain/usecase/GetAllOrdersUseCase.kt
+++ b/admin/domain/src/main/java/com/mtdevelopment/admin/domain/usecase/GetAllOrdersUseCase.kt
@@ -1,20 +1,34 @@
 package com.mtdevelopment.admin.domain.usecase
 
 import com.mtdevelopment.admin.domain.repository.FirebaseAdminRepository
+import com.mtdevelopment.core.domain.toTimeStamp
 import com.mtdevelopment.core.model.Order
+import com.mtdevelopment.core.model.OrderStatus
 
 /**
  * Use case to retrieve all orders from the Firebase database.
+ *
+ * Orders with a failed payment ([OrderStatus.CANCELED], the terminal status written when a
+ * SumUp checkout fails) are excluded here so they never reach the UI state. The remaining
+ * orders are sorted by delivery date, newest first, so consumers get the same deterministic
+ * order regardless of the backend's document order.
  */
 class GetAllOrdersUseCase(
     private val firebaseAdminRepository: FirebaseAdminRepository
 ) {
     /**
      * Executes the use case.
-     * @param onSuccess Callback invoked with the list of orders, or null if an error occurs.
+     * @param onSuccess Callback invoked with the filtered and sorted list of orders,
+     * or null if an error occurs.
      */
     suspend operator fun invoke(onSuccess: (List<Order>?) -> Unit) {
-        firebaseAdminRepository.getAllOrders(onSuccess)
+        firebaseAdminRepository.getAllOrders { orders ->
+            onSuccess.invoke(
+                orders
+                    ?.filterNot { it.status == OrderStatus.CANCELED }
+                    ?.sortedByDescending { it.deliveryDate.toTimeStamp() }
+            )
+        }
     }
 
 }

--- a/admin/domain/src/test/java/com/mtdevelopment/admin/domain/usecase/GetAllOrdersUseCaseTest.kt
+++ b/admin/domain/src/test/java/com/mtdevelopment/admin/domain/usecase/GetAllOrdersUseCaseTest.kt
@@ -1,0 +1,78 @@
+package com.mtdevelopment.admin.domain.usecase
+
+import com.mtdevelopment.admin.domain.repository.FirebaseAdminRepository
+import com.mtdevelopment.core.model.Order
+import com.mtdevelopment.core.model.OrderStatus
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GetAllOrdersUseCaseTest {
+
+    private val repository: FirebaseAdminRepository = mockk()
+    private val useCase = GetAllOrdersUseCase(repository)
+
+    private fun order(id: String, deliveryDate: String, status: OrderStatus) = Order(
+        id = id,
+        customerName = "Jean Dupont",
+        customerAddress = "1 Rue de la Paix, 75002 Paris",
+        customerBillingAddress = "1 Rue de la Paix, 75002 Paris",
+        deliveryDate = deliveryDate,
+        orderDate = "01/01/2026",
+        products = mapOf("Comté AOP" to 2),
+        status = status,
+        note = null,
+        isManuallyAdded = false
+    )
+
+    private fun givenRepositoryReturns(orders: List<Order>?) {
+        coEvery { repository.getAllOrders(any()) } coAnswers {
+            firstArg<(List<Order>?) -> Unit>().invoke(orders)
+        }
+    }
+
+    @Test
+    fun `orders are sorted by delivery date descending`() = runTest {
+        givenRepositoryReturns(
+            listOf(
+                order("old", "02/01/2026", OrderStatus.PAID),
+                order("newest", "15/03/2026", OrderStatus.PAID),
+                order("middle", "20/02/2026", OrderStatus.PAID)
+            )
+        )
+
+        var result: List<Order>? = null
+        useCase.invoke { result = it }
+
+        assertEquals(listOf("newest", "middle", "old"), result?.map { it.id })
+    }
+
+    @Test
+    fun `orders with failed payment never reach the result`() = runTest {
+        givenRepositoryReturns(
+            listOf(
+                order("paid", "02/01/2026", OrderStatus.PAID),
+                order("failed", "15/03/2026", OrderStatus.CANCELED),
+                order("pending", "20/02/2026", OrderStatus.PENDING)
+            )
+        )
+
+        var result: List<Order>? = null
+        useCase.invoke { result = it }
+
+        assertEquals(listOf("pending", "paid"), result?.map { it.id })
+    }
+
+    @Test
+    fun `repository failure propagates null`() = runTest {
+        givenRepositoryReturns(null)
+
+        var result: List<Order>? = emptyList()
+        useCase.invoke { result = it }
+
+        assertNull(result)
+    }
+}

--- a/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/screen/OrderPreparationScreen.kt
+++ b/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/screen/OrderPreparationScreen.kt
@@ -38,18 +38,21 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.mtdevelopment.admin.presentation.viewmodel.AdminViewModel
+import com.mtdevelopment.core.domain.toLocalDate
 import com.mtdevelopment.core.domain.toTimeStamp
 import com.mtdevelopment.core.model.Order
 import com.mtdevelopment.core.model.PreparationStatus
 import com.mtdevelopment.core.presentation.composable.ErrorOverlay
 import com.mtdevelopment.core.presentation.composable.RiveAnimation
 import com.mtdevelopment.core.util.koinViewModel
+import java.time.LocalDate
 
 /**
  * Screen for administrative order preparation.
@@ -97,15 +100,20 @@ fun OrderPreparationList(
     preparationStatuses: List<PreparationStatus>,
     onUpdateStatus: (PreparationStatus) -> Unit
 ) {
-    // Sort and unique delivery dates
+    // Sort and unique delivery dates, newest first
     val nextDeliveryDates =
-        orders.map { it.deliveryDate }.sortedBy { it.toTimeStamp() }.toSet()
+        orders.map { it.deliveryDate }.sortedByDescending { it.toTimeStamp() }.toSet()
     val ordersByDeliveryDate = orders.groupBy { it.deliveryDate }
+
+    // Captured once so every item of a frame compares against the same day and
+    // scrolling does not re-evaluate the clock.
+    val today = remember { LocalDate.now() }
 
     LazyColumn {
 
         for (deliveryDate in nextDeliveryDates) {
             val ordersForDate = ordersByDeliveryDate[deliveryDate] ?: emptyList()
+            val isPastDate = deliveryDate.toLocalDate()?.isBefore(today) == true
             if (ordersForDate.isNotEmpty()) {
 
                 // Aggregate product quantities for the current delivery date.
@@ -119,10 +127,17 @@ fun OrderPreparationList(
                     }
 
                 stickyHeader {
+                    // Past dates get a muted header so expired deliveries read as history
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .background(color = MaterialTheme.colorScheme.secondary)
+                            .background(
+                                color = if (isPastDate) {
+                                    MaterialTheme.colorScheme.surfaceVariant
+                                } else {
+                                    MaterialTheme.colorScheme.secondary
+                                }
+                            )
                     ) {
                         Text(
                             modifier = Modifier
@@ -130,7 +145,11 @@ fun OrderPreparationList(
                                 .align(Alignment.CenterStart),
                             text = deliveryDate,
                             style = MaterialTheme.typography.titleLarge,
-                            color = MaterialTheme.colorScheme.onSecondary
+                            color = if (isPastDate) {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            } else {
+                                MaterialTheme.colorScheme.onSecondary
+                            }
                         )
                     }
                 }
@@ -156,6 +175,7 @@ fun OrderPreparationList(
                         quantity = item.second,
                         itemsPerClients = ordersByDeliveryDate[deliveryDate] ?: listOf(),
                         deliveryDate = deliveryDate,
+                        isPastDate = isPastDate,
                         preparationStatuses = preparationStatuses,
                         onUpdateStatus = onUpdateStatus
                     )
@@ -177,6 +197,7 @@ fun OrderPreparationListItem(
     quantity: Int,
     itemsPerClients: List<Order>,
     deliveryDate: String,
+    isPastDate: Boolean,
     preparationStatuses: List<PreparationStatus>,
     onUpdateStatus: (PreparationStatus) -> Unit
 ) {
@@ -212,7 +233,10 @@ fun OrderPreparationListItem(
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp),
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            // Past/expired deliveries are faded out as a whole, keeping their inner
+            // colors and layout untouched
+            .alpha(if (isPastDate) 0.6f else 1f),
         shape = RoundedCornerShape(12.dp),
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
         colors = CardColors(

--- a/core/domain/consumer-rules.pro
+++ b/core/domain/consumer-rules.pro
@@ -1,0 +1,5 @@
+# Order statuses are resolved by constant name from Firestore documents
+# (OrderStatus.valueOf in the admin data source). R8 must not rename or strip
+# the enum constants, otherwise every order silently falls back to PENDING in
+# release builds and status-based filtering (e.g. failed payments) breaks.
+-keepclassmembers enum com.mtdevelopment.core.model.OrderStatus { *; }

--- a/core/domain/src/main/java/com/mtdevelopment/core/domain/LogicUtils.kt
+++ b/core/domain/src/main/java/com/mtdevelopment/core/domain/LogicUtils.kt
@@ -47,9 +47,12 @@ fun String.toLongPrice(): Long {
 
 /**
  * Formatter for dates in "dd/MM/yyyy" format using the system timezone.
+ * Pinned to [Locale.ROOT]: stored dates use ASCII digits, and a formatter built on the
+ * device default locale fails to parse them on locales with non-Latin digits, silently
+ * turning every timestamp-based sort into a no-op.
  */
 private val DATE_FORMATTER_DDMMYYYY: java.time.format.DateTimeFormatter =
-    java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy")
+    java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ROOT)
         .withZone(java.time.ZoneId.systemDefault())
 
 /**


### PR DESCRIPTION
## What changed

**Sorting (newest first, consistent across build types)**
- `GetAllOrdersUseCase` now sorts orders by delivery date descending, so every consumer (preparation screen, delivery helper, tracking service) gets one deterministic order. The screen's date grouping was flipped to descending as well.
- Root cause of the release-only anomaly: the shared `dd/MM/yyyy` formatter in `LogicUtils` was built on the device default locale. On locales with non-Latin digits, parsing the stored ASCII dates fails, `toTimeStamp()` returns `0L`, and the sort silently becomes a no-op. This only surfaces in release because debug returns pre-sorted generated fixtures instead of real Firestore data. The formatter is now pinned to `Locale.ROOT`.

**R8 hardening**
- `OrderStatus.valueOf(string)` resolves enum constants by name from Firestore documents, with a silent fallback to `PENDING`. Added a consumer ProGuard rule in `core/domain` keeping the enum constants so minified release builds cannot degrade every order to `PENDING` (which would also defeat the failed-payment filter below).

**Failed-payment filtering (domain layer)**
- A failed payment is persisted as `OrderStatus.CANCELED` (`FinalizePaymentWorker` maps SumUp `FAILED` to `CANCELED`). `GetAllOrdersUseCase` now filters these out before invoking its callback, so they never reach `OrderScreenState` or the UI.

**Past-order visual cue (Compose)**
- Delivery dates before today get a muted sticky header (`surfaceVariant`/`onSurfaceVariant`) and their product cards are faded via `Modifier.alpha(0.6f)`. `LocalDate.now()` is captured once in `remember`, and past-ness is passed down as a stable `Boolean`, so scrolling causes no extra recompositions. The UI stays passive, purely deriving presentation from the state-provided list.

## Tests
- New `GetAllOrdersUseCaseTest`: descending sort, `CANCELED` orders never reaching the result, null propagation on repository failure — all passing.
- Existing `LogicUtils` tests still pass; `admin:presentation` compiles in both debug and release.
- Note: two `AdminViewModelTest` product-image-upload tests fail identically on a clean checkout of `main` — pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)