### PR TITLE
Improve client UX: cart quantity stepper, conditional back arrow, subtler add-to-cart buttons

### DIFF
--- a/app/src/client/java/com/mtdevelopment/lafromagerie/MainActivity.kt
+++ b/app/src/client/java/com/mtdevelopment/lafromagerie/MainActivity.kt
@@ -187,12 +187,19 @@ class MainActivity : ComponentActivity() {
                                 Text("La Fromagerie")
                             },
                             navigationIcon = {
+                                // previousBackStackEntry is not snapshot state: it is re-read here
+                                // on every back stack change because currentBackStackEntry is.
+                                val currentRoute =
+                                    currentBackStackEntry.value?.destination?.route
+                                val canNavigateBack =
+                                    navController.previousBackStackEntry != null &&
+                                            currentRoute?.replace(
+                                                "?shouldRefresh={shouldRefresh}",
+                                                ""
+                                            ) != HomeScreenDestination::class.java.name &&
+                                            currentRoute != AfterPaymentScreenDestination::class.java.name
                                 AnimatedVisibility(
-                                    visible = currentBackStackEntry.value?.destination?.route?.replace(
-                                        "?shouldRefresh={shouldRefresh}",
-                                        ""
-                                    ) != HomeScreenDestination::class.java.name &&
-                                            currentBackStackEntry.value?.destination?.route != AfterPaymentScreenDestination::class.java.name,
+                                    visible = canNavigateBack,
                                     exit = fadeOut(animationSpec = tween(300)),
                                     enter = fadeIn(animationSpec = tween(500))
                                 ) {

--- a/home/presentation/src/client/java/com/mtdevelopment/home/presentation/composable/ProductItem.kt
+++ b/home/presentation/src/client/java/com/mtdevelopment/home/presentation/composable/ProductItem.kt
@@ -227,21 +227,54 @@ fun ProductItem(
                 }
 
 
+                // LESS INTRUSIVE, BUT LESS VISIBLE
+//                if (product?.isAvailable == true) {
+//                    FilledTonalIconButton(
+//                        modifier = Modifier.size(36.dp),
+//                        onClick = {
+//                            vibratePhoneClick(context)
+//                            animateAddToCart()
+//                            onAddClick.invoke()
+//                        },
+//                        colors = IconButtonDefaults.filledTonalIconButtonColors(
+//                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+//                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+//                        )
+//                    ) {
+//                        Icon(
+//                            modifier = Modifier.size(20.dp),
+//                            imageVector = Icons.Default.Add,
+//                            contentDescription = "Add"
+//                        )
+//                    }
+//                }
+
+                // MORE INTRUSIVE, BUT MORE VISIBLE
                 if (product?.isAvailable == true) {
-                    FilledTonalIconButton(
-                        modifier = Modifier.size(36.dp),
+                    Button(
+                        modifier = Modifier
+                            .width(32.dp)
+                            .height(32.dp),
                         onClick = {
                             vibratePhoneClick(context)
                             animateAddToCart()
                             onAddClick.invoke()
                         },
-                        colors = IconButtonDefaults.filledTonalIconButtonColors(
-                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
-                        )
+                        colors = ButtonColors(
+                            containerColor = MaterialTheme.colorScheme.secondary,
+                            contentColor = MaterialTheme.colorScheme.primaryContainer,
+                            disabledContainerColor = MaterialTheme.colorScheme.secondary,
+                            disabledContentColor = MaterialTheme.colorScheme.primaryContainer
+                        ),
+                        contentPadding = PaddingValues(4.dp),
+                        border = BorderStroke(
+                            width = 2.dp,
+                            color = MaterialTheme.colorScheme.secondary
+                        ),
+                        elevation = ButtonDefaults.elevatedButtonElevation(),
+                        shape = RoundedCornerShape(8.dp)
                     ) {
                         Icon(
-                            modifier = Modifier.size(20.dp),
                             imageVector = Icons.Default.Add,
                             contentDescription = "Add"
                         )

--- a/home/presentation/src/client/java/com/mtdevelopment/home/presentation/composable/ProductItem.kt
+++ b/home/presentation/src/client/java/com/mtdevelopment/home/presentation/composable/ProductItem.kt
@@ -3,31 +3,28 @@ package com.mtdevelopment.home.presentation.composable
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonColors
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -231,30 +228,20 @@ fun ProductItem(
 
 
                 if (product?.isAvailable == true) {
-                    Button(
-                        modifier = Modifier
-                            .width(32.dp)
-                            .height(32.dp),
+                    FilledTonalIconButton(
+                        modifier = Modifier.size(36.dp),
                         onClick = {
                             vibratePhoneClick(context)
                             animateAddToCart()
                             onAddClick.invoke()
                         },
-                        colors = ButtonColors(
-                            containerColor = MaterialTheme.colorScheme.secondary,
-                            contentColor = MaterialTheme.colorScheme.primaryContainer,
-                            disabledContainerColor = MaterialTheme.colorScheme.secondary,
-                            disabledContentColor = MaterialTheme.colorScheme.primaryContainer
-                        ),
-                        contentPadding = PaddingValues(4.dp),
-                        border = BorderStroke(
-                            width = 2.dp,
-                            color = MaterialTheme.colorScheme.secondary
-                        ),
-                        elevation = ButtonDefaults.elevatedButtonElevation(),
-                        shape = RoundedCornerShape(8.dp)
+                        colors = IconButtonDefaults.filledTonalIconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                        )
                     ) {
                         Icon(
+                            modifier = Modifier.size(20.dp),
                             imageVector = Icons.Default.Add,
                             contentDescription = "Add"
                         )

--- a/home/presentation/src/main/java/com/mtdevelopment/home/presentation/composable/cart/CartItem.kt
+++ b/home/presentation/src/main/java/com/mtdevelopment/home/presentation/composable/cart/CartItem.kt
@@ -9,13 +9,16 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxState
@@ -27,6 +30,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mtdevelopment.core.model.CartItem
@@ -114,30 +118,46 @@ fun CartItem(
                     )
                 }
                 Row(
-                    horizontalArrangement = Arrangement.SpaceBetween
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
                     // Quantity controls
-                    IconButton(onClick = { onRemoveOne.invoke() }) {
+                    FilledTonalIconButton(
+                        modifier = Modifier
+                            .padding(4.dp)
+                            .size(32.dp),
+                        colors = IconButtonDefaults.filledTonalIconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                        ),
+                        onClick = { onRemoveOne.invoke() }
+                    ) {
                         Icon(
-                            modifier = Modifier
-                                .align(Alignment.CenterVertically)
-                                .padding(4.dp)
-                                .size(32.dp),
-                            imageVector = Icons.Default.KeyboardArrowDown,
+                            modifier = Modifier.size(20.dp),
+                            imageVector = Icons.Default.Remove,
                             contentDescription = "Remove one"
                         )
                     }
                     Text(
-                        modifier = Modifier.align(Alignment.CenterVertically),
-                        text = item.quantity.toString()
+                        modifier = Modifier
+                            .padding(horizontal = 4.dp)
+                            .widthIn(min = 20.dp),
+                        text = item.quantity.toString(),
+                        style = MaterialTheme.typography.titleMedium,
+                        textAlign = TextAlign.Center
                     )
-                    IconButton(onClick = { onAddMore.invoke() }) {
+                    FilledTonalIconButton(
+                        modifier = Modifier
+                            .padding(4.dp)
+                            .size(32.dp),
+                        colors = IconButtonDefaults.filledTonalIconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                        ),
+                        onClick = { onAddMore.invoke() }
+                    ) {
                         Icon(
-                            modifier = Modifier
-                                .align(Alignment.CenterVertically)
-                                .padding(4.dp)
-                                .size(32.dp),
-                            imageVector = Icons.Default.KeyboardArrowUp,
+                            modifier = Modifier.size(20.dp),
+                            imageVector = Icons.Default.Add,
                             contentDescription = "Add more"
                         )
                     }


### PR DESCRIPTION
## What changed

**1. Cart quantity selector** (`CartItem.kt`)
The up/down keyboard arrows are replaced with a proper stepper: circular `FilledTonalIconButton`s with minus/plus icons flanking the quantity, which now uses `titleMedium` and a min-width so the row doesn't shift as the number changes. UDF is untouched — the buttons emit the existing `onRemoveOne`/`onAddMore` callbacks that `CartView` routes to `CartViewModel.removeCartObject()`/`addCartObject()`.

**2. Conditional back navigation** (client `MainActivity.kt`)
The top bar back arrow is now driven primarily by `navController.previousBackStackEntry != null`, so it only renders when there is actually somewhere to pop to. The explicit Home and AfterPayment route exclusions are kept on top, because the post-payment flow can leave a Home→Home stack where a previous entry exists but a back arrow would be wrong.

**3. Homepage add-to-cart buttons** (client `ProductItem.kt`)
The old button stacked a solid `secondary` fill, a 2dp border, and elevation on every tile — too visually aggressive. It is now a flat `FilledTonalIconButton` on `secondaryContainer`, keeping the same position, haptic feedback, and bounce animation. (Alternatives considered: `OutlinedIconButton` — reads as disabled in some themes; icon overlay on the product photo — poor contrast over busy images.)

## Why

User feedback: the homepage `+` buttons felt dominant, the cart arrows were unintuitive, and the back arrow appeared on screens where it had nothing to pop back to.

## Verification

Verified on an emulator running `clientDebug`:
- No back arrow on Home; it appears on the detail screen and navigates back correctly, disappearing again on Home.
- Cart stepper went 2 → 3 → 1 with the total updating instantly (7,40 € → 11,10 € → 3,70 €) and no layout shift.
- `:home:presentation` and `:app` compile clean; existing unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)