### PR TITLE
Fix getDeliveryPath querying non-existent pathName field

### DIFF
--- a/delivery/data/src/main/java/com/mtdevelopment/delivery/data/source/remote/FirestoreDeliveryDataSource.kt
+++ b/delivery/data/src/main/java/com/mtdevelopment/delivery/data/source/remote/FirestoreDeliveryDataSource.kt
@@ -37,7 +37,7 @@ class FirestoreDeliveryDataSource(
         onFailure: () -> Unit
     ) {
         firestore.collection("delivery_paths")
-            .whereEqualTo("pathName", pathName)
+            .whereEqualTo("path_name", pathName)
             .get()
             .addOnFailureListener {
                 onFailure.invoke()

--- a/delivery/data/src/test/java/com/mtdevelopment/delivery/data/source/remote/FirestoreDeliveryDataSourceTest.kt
+++ b/delivery/data/src/test/java/com/mtdevelopment/delivery/data/source/remote/FirestoreDeliveryDataSourceTest.kt
@@ -1,0 +1,80 @@
+package com.mtdevelopment.delivery.data.source.remote
+
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.QuerySnapshot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FirestoreDeliveryDataSourceTest {
+
+    private val firestore: FirebaseFirestore = mockk()
+    private val collection: CollectionReference = mockk()
+    private val query: Query = mockk()
+    private val task: Task<QuerySnapshot> = mockk(relaxed = true)
+
+    private val dataSource = FirestoreDeliveryDataSource(firestore)
+
+    @Test
+    fun `getDeliveryPath queries the stored path_name field, not pathName`() {
+        val fieldSlot = slot<String>()
+        every { firestore.collection("delivery_paths") } returns collection
+        every { collection.whereEqualTo(capture(fieldSlot), any<String>()) } returns query
+        every { query.get() } returns task
+
+        dataSource.getDeliveryPath(
+            pathName = "Vercors",
+            onSuccess = {},
+            onFailure = {}
+        )
+
+        // Regression guard for the latent bug: the stored Firestore field is `path_name`
+        // (see getAllDeliveryPaths / the admin write DTO), NOT `pathName`. Querying the
+        // wrong key silently matched nothing.
+        verify { collection.whereEqualTo("path_name", "Vercors") }
+        assertEquals("path_name", fieldSlot.captured)
+    }
+
+    @Test
+    fun `getDeliveryPath maps the first matching document to a response`() {
+        every { firestore.collection("delivery_paths") } returns collection
+        every { collection.whereEqualTo(any<String>(), any<String>()) } returns query
+        every { query.get() } returns task
+
+        val successSlot = slot<OnSuccessListener<QuerySnapshot>>()
+        every { task.addOnFailureListener(any()) } returns task
+        every { task.addOnSuccessListener(capture(successSlot)) } returns task
+
+        val document: DocumentSnapshot = mockk()
+        every { document.id } returns "path-1"
+        every { document.data } returns mapOf(
+            "path_name" to "Vercors",
+            "cities" to listOf("Grenoble"),
+            "delivery_day" to "MONDAY",
+            "postcodes" to listOf(38000),
+            "streets" to listOf("Rue de la Fromagerie")
+        )
+        val snapshot: QuerySnapshot = mockk()
+        every { snapshot.documents } returns listOf(document)
+
+        var result = mutableListOf<String?>()
+        dataSource.getDeliveryPath(
+            pathName = "Vercors",
+            onSuccess = { result.add(it.path_name) },
+            onFailure = { result.add(null) }
+        )
+
+        successSlot.captured.onSuccess(snapshot)
+
+        assertEquals(listOf("Vercors"), result)
+    }
+}


### PR DESCRIPTION
## What

`FirestoreDeliveryDataSource.getDeliveryPath` filtered `delivery_paths` on `whereEqualTo("pathName", …)`, but the stored Firestore field is **`path_name`** — the same key written by the admin `DataDeliveryPath` write DTO and read by `getAllDeliveryPaths` in this very file. The query filtered on a field that does not exist, so it could never match and the method never returned a path.

The method is wired end-to-end (`FirestorePathRepositoryImpl.getDeliveryPath` → `GetDeliveryPathUseCase` → injected into `DeliveryViewModel`) but is **currently uninvoked** in main source, which is why the bug stayed latent — it neither matched nor was exercised.

## Change

- Query now filters on `path_name` (one-line fix).
- New `FirestoreDeliveryDataSourceTest` with two cases: a regression guard asserting the query key is `path_name` (not `pathName`), and a success-path test asserting the first matching document maps into the response.

## Safety / change-control

- **Read-only query fix.** No stored field is renamed, added, or removed — fully backward-compatible with APKs in the field. No schema change.
- **No prod Firestore writes** were performed. Verification is via unit tests only.
- `:delivery:data` unit tests pass on **both** flavors (`testClientDebugUnitTest`, `testAdminDebugUnitTest`).

The two skill entries that documented this as a "latent bug" (`fromagerie-firestore-data-model` §2.3 and `fromagerie-delivery-logistics-reference`) live on the separate `claude/distracted-chaum-0986e4` branch and are being updated there to reference this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)