### PR TITLE
Skills: mark getDeliveryPath pathName bug as fixed

### DIFF
--- a/.claude/skills/fromagerie-delivery-logistics-reference/SKILL.md
+++ b/.claude/skills/fromagerie-delivery-logistics-reference/SKILL.md
@@ -67,7 +67,7 @@ with live route guidance. All facts verified 2026-07-06 against branch `claude/d
 4. If `withGeoJson = true` (admin map only, see below), fetch road-line geometry from OpenRouteService using the resolved city coordinates.
 5. If **all** paths in the whole fetch failed to geocode, `onFailure` fires; otherwise the (possibly-partial) successful list is returned via `onSuccess`.
 
-`getDeliveryPath(pathName)` (used to resolve a customer's previously-saved path name) does **not** geocode or fetch GeoJSON — it is a lighter partial reconstruction. **KNOWN LATENT BUG (as of 2026-07-06):** this method queries `whereEqualTo("pathName", …)` but the stored Firestore field is `path_name`, so the query can never match — see `fromagerie-firestore-data-model` §2.3 before relying on or "fixing" it.
+`getDeliveryPath(pathName)` (used to resolve a customer's previously-saved path name) does **not** geocode or fetch GeoJSON — it is a lighter partial reconstruction. **FIXED (2026-07-07, commit `58f85c9`, PR #43):** this method previously queried `whereEqualTo("pathName", …)` while the stored Firestore field is `path_name`, so the query could never match. The query key is now `path_name` and a regression test (`FirestoreDeliveryDataSourceTest`) guards it — see `fromagerie-firestore-data-model` §2.3.
 
 ### Address APIs — which does what
 

--- a/.claude/skills/fromagerie-firestore-data-model/SKILL.md
+++ b/.claude/skills/fromagerie-firestore-data-model/SKILL.md
@@ -117,16 +117,18 @@ the `@Serializable` DTO. Unknown/newer status values from a future app version d
   (`delivery/data/.../FirestoreDeliveryDataSource`) reads `path_name`, `cities`,
   `delivery_day`, `postcodes`, **and `streets` (List&lt;String&gt;)**.
 
-⚠️ **Two real inconsistencies in `delivery_paths` — verify before editing:**
+⚠️ **Inconsistencies in `delivery_paths` — verify before editing** (item 1 live; item 2 fixed 2026-07-07):
 1. The reader expects a **`streets`** field that the admin write DTO (`DataDeliveryPath`)
    does **not** write. Streets are populated by other write paths (fine-grained streets, see
    git `bb3d36a`), so `streets` may be absent on older path docs — the reader defaults to
    `emptyList()`. Additive field; keep defaulting.
-2. `FirestoreDeliveryDataSource.getDeliveryPath` queries
-   `whereEqualTo("pathName", pathName)` — but the stored field is `path_name`. This query
-   filters on a field that does not exist and will not match. Looks like a latent bug; do
-   not "rely" on this method returning results. (Report via change-control, don't silently
-   rename in prod.)
+2. `FirestoreDeliveryDataSource.getDeliveryPath` **used to** query
+   `whereEqualTo("pathName", pathName)` while the stored field is `path_name`, so it filtered
+   on a non-existent field and never matched. **FIXED 2026-07-07 (commit `58f85c9`, PR #43):**
+   the query now uses `path_name` (matching the write DTO and `getAllDeliveryPaths`), and
+   `FirestoreDeliveryDataSourceTest` asserts the field name as a regression guard. No stored
+   field changed — read-query fix only, so no schema/compat impact. (The method is still
+   uninvoked in main source; the fix makes it correct for when it is wired up.)
 
 ### 2.4 `preparation_status`  — DTO `PreparationStatusData` (`core/data/.../model/PreparationStatusData.kt`)
 


### PR DESCRIPTION
Docs-only follow-up to PR #43.

PR #43 fixed the `getDeliveryPath` query (`pathName` → `path_name`, commit `58f85c9`), and PR #42 landed the skill library — but #42 merged the version that still described the bug as a **latent bug**. This updates the two skill entries now on `main` to reflect that it's fixed:

- `fromagerie-firestore-data-model` §2.3 — the `delivery_paths` inconsistency list
- `fromagerie-delivery-logistics-reference` — the `getDeliveryPath` cross-reference

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)