### PR TITLE
feat(backend): auto-invoice paid orders via Invoice Ninja

### DIFF
--- a/la-fromagerie-backend/functions/.env.example
+++ b/la-fromagerie-backend/functions/.env.example
@@ -1,0 +1,23 @@
+# Firebase Functions env — copiez vers `.env` (gitignoré) et remplissez.
+# Chargé automatiquement par `firebase deploy --only functions`.
+
+# --- SumUp (déjà utilisés par createSumUpCheckout) ---
+SUMUP_SECRET_KEY=sup_sk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+SUMUP_MERCHANT_CODE=MFHN73AC
+
+# URL publique de handleSumUpWebhook, une fois déployée. Renseignez-la puis
+# redéployez : createSumUpCheckout ajoutera alors return_url à chaque checkout
+# pour abonner SumUp aux notifications de statut.
+# ex: https://handlesumupwebhook-xxxxxxxxxx-uc.a.run.app
+SUMUP_WEBHOOK_URL=
+
+# Optionnel : secret HMAC pour vérifier x-payload-signature. Laissez vide tant
+# que SumUp ne fournit pas de signature ; la sécurité repose alors sur la
+# re-vérification via l'API SumUp. Si renseigné, toute requête mal signée est rejetée.
+SUMUP_WEBHOOK_SECRET=
+
+# --- Invoice Ninja (v5, self-hosted homelab) ---
+# URL racine SANS /api/v1 (le client l'ajoute). ex: https://invoices.mondomaine.fr
+INVOICE_NINJA_URL=https://invoices.example.com
+# Jeton API v5 (Settings > Account Management > API Tokens).
+INVOICE_NINJA_TOKEN=

--- a/la-fromagerie-backend/functions/src/billing.ts
+++ b/la-fromagerie-backend/functions/src/billing.ts
@@ -1,0 +1,180 @@
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+import { InvoiceLine, InvoiceNinjaClient, describeError } from "./invoiceNinja.js";
+
+/**
+ * Logique de facturation partagée entre les deux déclencheurs :
+ *  - handleSumUpWebhook (chemin hosted-checkout, vérifié côté SumUp) ;
+ *  - onOrderPaidCreateInvoice (trigger Firestore, couvre TOUS les chemins de
+ *    paiement dès que la commande passe à PAID).
+ *
+ * Idempotent : chaque commande est facturée une seule fois, via une
+ * réclamation transactionnelle dans la collection `invoices`. Les deux
+ * déclencheurs peuvent donc coexister sans risque de double facture.
+ */
+
+export type InvoiceResult =
+    | { status: "invoiced"; invoiceId: string }
+    | { status: "skipped"; reason: string }
+    | { status: "failed"; reason: string };
+
+export interface InvoiceOptions {
+    /** Si fourni, doit égaler le total commande (garde-fou du webhook SumUp). */
+    expectedAmountCents?: number;
+    /** Email de repli (ex. personal_details.email du checkout SumUp). */
+    fallbackEmail?: string;
+}
+
+/**
+ * Facture une commande PAID : réclame -> lit la commande -> Invoice Ninja
+ * (client, facture, paiement, email) -> marque facturée.
+ *
+ * En cas de panne transitoire (Invoice Ninja injoignable…), la réclamation est
+ * relâchée et le statut `failed` est renvoyé pour que l'appelant relance.
+ */
+export async function createAndSendInvoice(
+    orderId: string,
+    opts: InvoiceOptions = {},
+): Promise<InvoiceResult> {
+    const claimed = await claimInvoice(orderId);
+    if (!claimed) {
+        // Une autre invocation détient la réclamation : ne PAS la relâcher.
+        return { status: "skipped", reason: "déjà facturée / en cours" };
+    }
+
+    try {
+        const orderSnap = await getFirestore().collection("orders").doc(orderId).get();
+        if (!orderSnap.exists) {
+            await releaseClaim(orderId);
+            return { status: "skipped", reason: "commande introuvable" };
+        }
+
+        const orderTotalCents = orderSnap.get("total_price");
+        const email = orderSnap.get("customer_email") ?? opts.fallbackEmail;
+        const customerName = orderSnap.get("customer_name") ?? "Client";
+        const billingAddress = orderSnap.get("billing_address")
+            ?? orderSnap.get("customer_address") ?? "";
+        const deliveryDate = orderSnap.get("delivery_date");
+        const products = (orderSnap.get("products") ?? {}) as Record<string, number>;
+
+        if (typeof orderTotalCents !== "number" || orderTotalCents <= 0) {
+            await releaseClaim(orderId);
+            return { status: "skipped", reason: `total_price invalide (${orderTotalCents})` };
+        }
+        if (opts.expectedAmountCents != null && opts.expectedAmountCents !== orderTotalCents) {
+            await releaseClaim(orderId);
+            return {
+                status: "skipped",
+                reason: `montant incohérent (attendu=${opts.expectedAmountCents}, commande=${orderTotalCents})`,
+            };
+        }
+        if (typeof email !== "string" || !email.includes("@")) {
+            await releaseClaim(orderId);
+            return { status: "skipped", reason: "email client manquant" };
+        }
+
+        const lines = await buildInvoiceLines(products, orderId, orderTotalCents);
+        const invoiceNinja = new InvoiceNinjaClient(
+            process.env.INVOICE_NINJA_URL ?? "",
+            process.env.INVOICE_NINJA_TOKEN ?? "",
+        );
+        const invoiceReq = {
+            email,
+            clientName: customerName,
+            billingAddress,
+            orderId,
+            lines,
+            totalCents: orderTotalCents,
+            deliveryDate,
+        };
+        const clientId = await invoiceNinja.findOrCreateClient(invoiceReq);
+        const invoiceId = await invoiceNinja.createInvoice(clientId, invoiceReq);
+        await invoiceNinja.markPaidAndEmail(invoiceId);
+
+        await markInvoiced(orderId, invoiceId);
+        return { status: "invoiced", invoiceId };
+    } catch (error) {
+        // Panne transitoire : on relâche la réclamation pour autoriser un retry.
+        await releaseClaim(orderId).catch(() => undefined);
+        return { status: "failed", reason: describeError(error) };
+    }
+}
+
+/**
+ * Réclame l'unique facture de cette commande via une transaction.
+ * Renvoie true si acquise, false si déjà réclamée/facturée.
+ */
+async function claimInvoice(orderId: string): Promise<boolean> {
+    const ref = getFirestore().collection("invoices").doc(orderId);
+    return getFirestore().runTransaction(async (tx) => {
+        const snap = await tx.get(ref);
+        if (snap.exists) {
+            return false;
+        }
+        tx.set(ref, {
+            order_id: orderId,
+            status: "processing",
+            created_at: FieldValue.serverTimestamp(),
+        });
+        return true;
+    });
+}
+
+/** Libère une réclamation (échec en cours de traitement) pour autoriser un retry. */
+async function releaseClaim(orderId: string): Promise<void> {
+    await getFirestore().collection("invoices").doc(orderId).delete();
+}
+
+/** Marque la commande comme facturée et envoyée. */
+async function markInvoiced(orderId: string, invoiceNinjaId: string): Promise<void> {
+    await getFirestore().collection("invoices").doc(orderId).set(
+        {
+            order_id: orderId,
+            status: "sent",
+            invoice_ninja_id: invoiceNinjaId,
+            sent_at: FieldValue.serverTimestamp(),
+        },
+        { merge: true },
+    );
+}
+
+/**
+ * Construit les lignes de facture depuis la collection `products`.
+ * Repli : commande sans produits ou produit introuvable -> une seule ligne au
+ * montant total débité (le total facturé reste exact).
+ */
+async function buildInvoiceLines(
+    products: Record<string, number>,
+    orderId: string,
+    totalCents: number,
+): Promise<InvoiceLine[]> {
+    const entries = Object.entries(products);
+    const fallback: InvoiceLine[] = [
+        { description: `Commande La Fromagerie #${orderId}`, unitPriceCents: totalCents, quantity: 1 },
+    ];
+    if (entries.length === 0) {
+        return fallback;
+    }
+
+    const db = getFirestore();
+    const docs = await Promise.all(
+        entries.map(([productId]) => db.collection("products").doc(productId).get()),
+    );
+
+    const lines: InvoiceLine[] = [];
+    let allResolved = true;
+    docs.forEach((snap, i) => {
+        const quantity = entries[i][1];
+        const name = snap.get("name");
+        const priceCents = snap.get("priceCents");
+        if (!snap.exists || typeof name !== "string" || typeof priceCents !== "number") {
+            allResolved = false;
+            return;
+        }
+        lines.push({ description: name, unitPriceCents: priceCents, quantity });
+    });
+
+    if (!allResolved || lines.length === 0) {
+        return fallback;
+    }
+    return lines;
+}

--- a/la-fromagerie-backend/functions/src/index.ts
+++ b/la-fromagerie-backend/functions/src/index.ts
@@ -1,9 +1,15 @@
 import { onRequest } from "firebase-functions/v2/https";
+import { onDocumentUpdated } from "firebase-functions/v2/firestore";
 import { initializeApp } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
+import { createHmac, timingSafeEqual } from "crypto";
 import axios, { AxiosError } from "axios";
+import { createAndSendInvoice } from "./billing.js";
+import { describeError } from "./invoiceNinja.js";
 
 initializeApp();
+
+const SUMUP_API = "https://api.sumup.com/v0.1";
 
 export const createSumUpCheckout = onRequest({ invoker: "public", cors: true }, async (req, res) => {
     // 1. Sécurité : On vérifie la méthode POST
@@ -35,10 +41,15 @@ export const createSumUpCheckout = onRequest({ invoker: "public", cors: true }, 
     const sumUpSecretKey = process.env.SUMUP_SECRET_KEY;
     const sumUpMerchantCode = process.env.SUMUP_MERCHANT_CODE;
 
+    // Abonnement webhook : si SUMUP_WEBHOOK_URL est défini, SumUp notifiera
+    // handleSumUpWebhook des changements de statut de ce checkout (return_url).
+    // Distinct de redirect_url (retour navigateur vers l'app). No-op si non défini.
+    const webhookUrl = process.env.SUMUP_WEBHOOK_URL;
+
     try {
-                // 3. Appel à l'API de SumUp
+        // 3. Appel à l'API de SumUp
         const response = await axios.post(
-            "https://api.sumup.com/v0.1/checkouts",
+            `${SUMUP_API}/checkouts`,
             {
                 amount: amount,
                 currency: "EUR",
@@ -47,7 +58,8 @@ export const createSumUpCheckout = onRequest({ invoker: "public", cors: true }, 
                 merchant_code: sumUpMerchantCode,
                 hosted_checkout: {
                     enabled: true
-                }
+                },
+                ...(webhookUrl ? { return_url: webhookUrl } : {})
             },
             {
                 headers: {
@@ -69,3 +81,143 @@ export const createSumUpCheckout = onRequest({ invoker: "public", cors: true }, 
         return;
     }
 });
+
+/**
+ * Facturation primaire : dès qu'une commande passe à PAID dans Firestore, on
+ * émet la facture Invoice Ninja. Couvre TOUS les chemins de paiement (Google
+ * Pay direct ET hosted-checkout), car les deux écrivent `status = PAID` sur la
+ * commande (avec le filet WorkManager). La commande fait foi : l'app n'écrit
+ * PAID qu'après avoir vérifié le paiement auprès de SumUp.
+ *
+ * `retry: true` : en cas de panne transitoire d'Invoice Ninja, on relève une
+ * erreur pour que le trigger soit rejoué (idempotent via la réclamation).
+ */
+export const onOrderPaidCreateInvoice = onDocumentUpdated(
+    { document: "orders/{orderId}", retry: true },
+    async (event) => {
+        const before = event.data?.before.data();
+        const after = event.data?.after.data();
+        if (!after) {
+            return;
+        }
+
+        // On ne déclenche que sur la TRANSITION vers PAID (pas les mises à jour
+        // ultérieures : IN_PREPARATION, DELIVERED…).
+        const becamePaid = after.status === "PAID" && before?.status !== "PAID";
+        if (!becamePaid) {
+            return;
+        }
+
+        const orderId = event.params.orderId;
+        const result = await createAndSendInvoice(orderId);
+
+        if (result.status === "invoiced") {
+            console.log(`Facture ${result.invoiceId} envoyée pour la commande ${orderId} (trigger Firestore).`);
+            return;
+        }
+        if (result.status === "skipped") {
+            console.log(`Commande ${orderId} non facturée (trigger Firestore) : ${result.reason}.`);
+            return;
+        }
+        // Panne transitoire : on relève pour rejouer le trigger.
+        throw new Error(`Facturation commande ${orderId} échouée : ${result.reason}`);
+    },
+);
+
+/**
+ * Webhook SumUp -> facturation Invoice Ninja (défense en profondeur pour le
+ * chemin hosted-checkout : SumUp ré-émet le webhook en cas d'échec, ce que le
+ * trigger Firestore ne fait pas si l'app n'écrit jamais PAID).
+ *
+ * SumUp appelle cette fonction sur tout changement de statut d'un checkout
+ * abonné (return_url). Le payload est minimal : `{ event_type, id }`. On ne lui
+ * fait donc PAS confiance : on relit le checkout via l'API SumUp, on vérifie
+ * PAID + montant, puis on délègue à la logique de facturation partagée
+ * (idempotente : ne double-facture jamais avec le trigger Firestore).
+ */
+export const handleSumUpWebhook = onRequest({ invoker: "public" }, async (req, res) => {
+    if (req.method !== "POST") {
+        res.status(405).send("Méthode non autorisée");
+        return;
+    }
+
+    // Vérification de signature (optionnelle). SumUp ne documente pas
+    // formellement de signature pour les webhooks checkout ; si un secret est
+    // configuré on rejette toute requête mal signée, sinon on s'appuie sur la
+    // re-vérification via l'API SumUp (recommandation officielle SumUp).
+    const webhookSecret = process.env.SUMUP_WEBHOOK_SECRET;
+    if (webhookSecret) {
+        if (!verifySignature(req.rawBody, req.get("x-payload-signature"), webhookSecret)) {
+            console.warn("Webhook SumUp : signature invalide, requête rejetée.");
+            res.status(401).send("Signature invalide");
+            return;
+        }
+    } else {
+        console.warn("SUMUP_WEBHOOK_SECRET non défini : signature non vérifiée (fallback = re-vérification API).");
+    }
+
+    const checkoutId = req.body?.id;
+    const eventType = req.body?.event_type;
+    if (typeof checkoutId !== "string" || checkoutId.trim() === "") {
+        res.status(400).send("id de checkout manquant");
+        return;
+    }
+    console.log(`Webhook SumUp reçu : event=${eventType} checkout=${checkoutId}`);
+
+    try {
+        // On relit le checkout via l'API SumUp (jamais le payload).
+        const sumUpSecretKey = process.env.SUMUP_SECRET_KEY;
+        const checkout = await axios.get(`${SUMUP_API}/checkouts/${checkoutId}`, {
+            headers: { "Authorization": `Bearer ${sumUpSecretKey}` },
+        });
+        const status = checkout.data?.status;
+        const orderId = checkout.data?.checkout_reference;
+        const paidAmountCents = Math.round(Number(checkout.data?.amount) * 100);
+        const emailFromSumUp = checkout.data?.personal_details?.email;
+
+        // On ne facture que les paiements aboutis. Tout autre statut : on acquitte.
+        if (status !== "PAID") {
+            console.log(`Checkout ${checkoutId} status=${status} — rien à facturer.`);
+            res.status(200).send("OK");
+            return;
+        }
+        if (typeof orderId !== "string" || orderId.trim() === "") {
+            console.error(`Checkout ${checkoutId} PAID mais checkout_reference absent.`);
+            res.status(200).send("OK (référence de commande absente)");
+            return;
+        }
+
+        const result = await createAndSendInvoice(orderId, {
+            expectedAmountCents: paidAmountCents,
+            fallbackEmail: emailFromSumUp,
+        });
+
+        if (result.status === "failed") {
+            // Réponse 5xx => SumUp réessaiera la livraison du webhook.
+            console.error(`Webhook facturation commande ${orderId} échouée : ${result.reason}`);
+            res.status(500).send("Erreur de traitement");
+            return;
+        }
+        console.log(`Webhook facturation commande ${orderId} : ${result.status} (${eventType}).`);
+        res.status(200).send("OK");
+        return;
+    } catch (error) {
+        console.error("Erreur webhook facturation :", describeError(error));
+        res.status(500).send("Erreur de traitement");
+        return;
+    }
+});
+
+/** Vérifie la signature HMAC-SHA256 du corps brut contre l'en-tête fourni. */
+function verifySignature(rawBody: Buffer, signatureHeader: string | undefined, secret: string): boolean {
+    if (!signatureHeader) {
+        return false;
+    }
+    const expected = createHmac("sha256", secret).update(rawBody).digest("hex");
+    const a = Buffer.from(expected);
+    const b = Buffer.from(signatureHeader);
+    if (a.length !== b.length) {
+        return false;
+    }
+    return timingSafeEqual(a, b);
+}

--- a/la-fromagerie-backend/functions/src/invoiceNinja.ts
+++ b/la-fromagerie-backend/functions/src/invoiceNinja.ts
@@ -1,0 +1,136 @@
+import axios, { AxiosError, AxiosInstance } from "axios";
+
+/**
+ * Petit client pour l'API Invoice Ninja v5 (self-hosted).
+ * Auth : header `X-Api-Token` (v5 ; c'était `X-Ninja-Token` en v4).
+ * Les montants Invoice Ninja sont en unités monétaires (euros), PAS en centimes.
+ */
+
+export interface InvoiceLine {
+    /** Libellé affiché sur la facture (nom du produit). */
+    description: string;
+    /** Prix unitaire en CENTIMES (converti en euros au moment de l'envoi). */
+    unitPriceCents: number;
+    quantity: number;
+}
+
+export interface InvoiceRequest {
+    email: string;
+    clientName: string;
+    billingAddress: string;
+    orderId: string;
+    lines: InvoiceLine[];
+    /** Montant total réellement débité (centimes) — fait foi sur le total facturé. */
+    totalCents: number;
+    deliveryDate?: string;
+}
+
+/** Centimes -> euros, 2 décimales (les montants ont au plus 2 décimales). */
+function centsToUnits(cents: number): number {
+    return Number((cents / 100).toFixed(2));
+}
+
+export class InvoiceNinjaClient {
+    private readonly http: AxiosInstance;
+
+    constructor(baseUrl: string, token: string) {
+        this.http = axios.create({
+            baseURL: `${baseUrl.replace(/\/+$/, "")}/api/v1`,
+            headers: {
+                "X-Api-Token": token,
+                "X-Requested-With": "XMLHttpRequest",
+                "Content-Type": "application/json",
+            },
+            timeout: 20000,
+        });
+    }
+
+    /** Trouve un client par email, sinon le crée. Renvoie l'id Invoice Ninja. */
+    async findOrCreateClient(req: InvoiceRequest): Promise<string> {
+        const existing = await this.http.get("/clients", {
+            params: { email: req.email, per_page: 1 },
+        });
+        const found = existing.data?.data?.[0]?.id as string | undefined;
+        if (found) {
+            return found;
+        }
+
+        const created = await this.http.post("/clients", {
+            name: req.clientName,
+            address1: req.billingAddress,
+            contacts: [
+                { first_name: req.clientName, email: req.email, send_email: true },
+            ],
+        });
+        const id = created.data?.data?.id as string | undefined;
+        if (!id) {
+            throw new Error("Invoice Ninja: id client manquant dans la réponse de création");
+        }
+        return id;
+    }
+
+    /**
+     * Crée une facture (statut brouillon) pour le client.
+     * Ajoute une ligne de réconciliation si la somme des lignes ne correspond
+     * pas au montant réellement débité (livraison, arrondis, remises…), afin
+     * que le total de la facture soit TOUJOURS égal au montant encaissé.
+     */
+    async createInvoice(clientId: string, req: InvoiceRequest): Promise<string> {
+        const lineItems = req.lines.map((l) => ({
+            product_key: l.description,
+            notes: l.description,
+            cost: centsToUnits(l.unitPriceCents),
+            quantity: l.quantity,
+        }));
+
+        const linesSum = req.lines.reduce(
+            (acc, l) => acc + l.unitPriceCents * l.quantity,
+            0,
+        );
+        const diffCents = req.totalCents - linesSum;
+        if (diffCents !== 0) {
+            const label = diffCents > 0 ? "Livraison / frais" : "Remise";
+            lineItems.push({
+                product_key: label,
+                notes: label,
+                cost: centsToUnits(diffCents),
+                quantity: 1,
+            });
+        }
+
+        const res = await this.http.post("/invoices", {
+            client_id: clientId,
+            po_number: req.orderId,
+            date: new Date().toISOString().slice(0, 10),
+            public_notes: req.deliveryDate
+                ? `Livraison prévue le ${req.deliveryDate}`
+                : "",
+            line_items: lineItems,
+        });
+        const id = res.data?.data?.id as string | undefined;
+        if (!id) {
+            throw new Error("Invoice Ninja: id facture manquant dans la réponse de création");
+        }
+        return id;
+    }
+
+    /** Action groupée Invoice Ninja (`mark_paid`, `email`, …). */
+    private async bulk(action: string, ids: string[]): Promise<void> {
+        await this.http.post("/invoices/bulk", { action, ids });
+    }
+
+    /** Marque la facture payée (crée le paiement côté IN) puis l'envoie par email. */
+    async markPaidAndEmail(invoiceId: string): Promise<void> {
+        await this.bulk("mark_paid", [invoiceId]);
+        await this.bulk("email", [invoiceId]);
+    }
+}
+
+/** Message d'erreur lisible pour les logs (axios ou autre). */
+export function describeError(error: unknown): string {
+    const err = error as AxiosError;
+    if (err.response) {
+        return `HTTP ${err.response.status} ${JSON.stringify(err.response.data)}`;
+    }
+    return err.message ?? String(error);
+}


### PR DESCRIPTION
## What & why

Automates order-confirmation invoicing on the Cloud Functions backend. When a customer's order is paid, the backend finds/creates the client in **Invoice Ninja (v5, self-hosted)**, generates an invoice, marks it **paid**, and **emails** it.

## Design (differs from the original webhook-only ask, on purpose)

- **Primary: Firestore trigger `onOrderPaidCreateInvoice`** on `orders/{orderId}` transition → `PAID`. Covers **both** payment paths (Google Pay direct **and** hosted checkout) from one place — both write `status=PAID` after the app verifies with SumUp, so the order doc is the source of truth. `retry: true` for transient Invoice Ninja outages.
- **Secondary: `handleSumUpWebhook`** — defense-in-depth for the hosted-checkout path (SumUp re-delivers on failure). The webhook payload is only `{event_type, id}`, so it **re-fetches the checkout from SumUp's API** (SumUp's own guidance — never trust the payload), requires `PAID`, and cross-checks the amount. Optional `x-payload-signature` HMAC gate.
- **Shared `billing.ts`** is **idempotent** via a transaction-claimed `invoices/{orderId}` doc, so both triggers coexist with **no double-invoicing**.

## Correctness / safety

- **Money stays cents-`Long`**; conversion to euros only at the Invoice Ninja boundary.
- Invoice total is **reconciled to the exact charged amount** (adds a "Livraison / frais" line for the delivery/rounding delta) so the invoice always equals what was charged.
- Line items itemized from the `products` collection (`name` + `priceCents`), with a single-line fallback if a product is missing.
- `createSumUpCheckout` gains an **opt-in** `return_url` (only when `SUMUP_WEBHOOK_URL` is set) — no behavior change until configured.

## Assumption

Assumes the order doc will carry `customer_email` (added in a separate worktree). Falls back to the SumUp checkout's `personal_details.email` on the webhook path; skips (logs) if no valid email.

## Config required before it works (see `functions/.env.example`)

- Invoice Ninja: **Company details, SMTP/email settings, generate API token** (blank instance).
- Firebase env: `INVOICE_NINJA_URL` (root, no `/api/v1`), `INVOICE_NINJA_TOKEN`; optional `SUMUP_WEBHOOK_URL`, `SUMUP_WEBHOOK_SECRET`.
- Invoice Ninja instance must be **reachable from Google Cloud** (homelab public HTTPS / tunnel).

## Deploy note (webhook only)

1. `firebase deploy --only functions:handleSumUpWebhook` → get URL
2. set `SUMUP_WEBHOOK_URL` in `functions/.env`
3. `firebase deploy --only functions` (so `createSumUpCheckout` sends `return_url`)

The Firestore trigger needs no such step.

## Testing

- `tsc --noEmit` passes. No unit tests yet (backend has none); manual verification pending against the live Invoice Ninja instance. Not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)