### PR TITLE
Switch Mapbox to the ndk27 artifacts for 16 KB page size support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ accompanist = "0.36.0"
 accompanist-permissions = "0.37.3"
 contentment = "2.0.1"
 # Maps
-mapbox = "11.6.1"
+mapbox = "11.18.2"
 mapbox-geojson = "7.3.1"
 location = "21.3.0"
 google-maps = "8.1.0"
@@ -182,8 +182,11 @@ androidx-navigation-common-ktx = { group = "androidx.navigation", name = "naviga
 
 
 ## Map
-mapbox = { module = "com.mapbox.maps:android", version.ref = "mapbox" }
-mapbox-extension = { module = "com.mapbox.extension:maps-compose", version.ref = "mapbox" }
+# The `-ndk27` artifacts are Mapbox's NDK 27 builds: their .so files are 16 KB
+# page-aligned, which Android 15+ 64-bit devices (and Google Play) require. The plain
+# `android`/`maps-compose` artifacts are still NDK 23 (4 KB) — do not switch back.
+mapbox = { module = "com.mapbox.maps:android-ndk27", version.ref = "mapbox" }
+mapbox-extension = { module = "com.mapbox.extension:maps-compose-ndk27", version.ref = "mapbox" }
 mapbox-geojson = { module = "com.mapbox.mapboxsdk:mapbox-sdk-geojson", version.ref = "mapbox-geojson" }
 google-maps = { module = "com.google.maps.android:maps-compose", version.ref = "google-maps" }
 


### PR DESCRIPTION
## Problème

Android 15+ utilise une taille de page mémoire de 16 KB sur les appareils 64 bits, et Google Play rejette désormais les APK dont les bibliothèques natives ne sont pas alignées en conséquence.

## Diagnostic

Scan de l'alignement ELF (`PT_LOAD`) de chaque `.so` packagé dans l'APK client. Mapbox est le **seul** coupable :

```
BAD align=4096   lib/arm64-v8a/libmapbox-common.so
BAD align=4096   lib/arm64-v8a/libmapbox-maps.so
BAD align=4096   lib/x86_64/libmapbox-common.so
BAD align=4096   lib/x86_64/libmapbox-maps.so
OK  align=16384  librive-android.so, libc++_shared.so, libimagepipeline.so,
                 libnative-filters.so, libnative-imagetranscoder.so,
                 libdatastore_shared_counter.so, libandroidx.graphics.path.so
```

Mapbox 11.6.1 est buildé avec le NDK 23, d'où l'alignement 4 KB. Toutes les autres bibliothèques natives de l'APK étaient déjà conformes.

Les entrées à 4096 sur `armeabi-v7a` / `x86` sont normales et sans effet : les 16 KB ne concernent que le 64 bits.

## Correctif

Mapbox publie depuis la 11.8.0 des artefacts `-ndk27`, buildés avec le NDK 27 et alignés 16 KB. Un seul fichier touché, `gradle/libs.versions.toml` :

- `mapbox` : `11.6.1` → `11.18.2`
- `com.mapbox.maps:android` → `com.mapbox.maps:android-ndk27`
- `com.mapbox.extension:maps-compose` → `maps-compose-ndk27`

`mapbox-sdk-geojson` est du Java pur, non concerné.

**Aucun changement de code source n'a été nécessaire.**

## Vérifications

| Gate | Résultat |
|---|---|
| `:app:assembleClientDebug` + `:app:assembleAdminDebug` | ✅ |
| Alignement 64 bits, APK client **et** admin | ✅ tout à 16384, plus aucun `BAD` |
| `zipalign -c -P 16` | ✅ Verification successful |
| `testClientDebugUnitTest` + `testAdminDebugUnitTest` | ✅ baseline seul |

Les tests unitaires remontent les 2 échecs connus d'`AdminViewModelTest` (`addNewProduct` / `updateProduct aborts when local image upload fails`), à l'identique sur les deux flavors. Aucun nouvel échec.

## À valider avant merge

Le saut **11.6 → 11.18** représente 12 versions mineures de Mapbox. Ça compile sans rien toucher, mais un changement subtil de rendu (styles, gestures, viewport) ne se verrait pas à la compilation — l'écran des zones de livraison mérite une vérification sur device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)