### PR TITLE
Document secret-handling risks: tracked gradle.properties and "null" builds

### DIFF
--- a/.claude/skills/fromagerie-config-and-secrets/SKILL.md
+++ b/.claude/skills/fromagerie-config-and-secrets/SKILL.md
@@ -103,8 +103,12 @@ as-is unless a change is explicitly scoped to remove it, and NEVER commit them u
 | `android.builtInKotlin` | `false` | **Temporary / must migrate** — AGP 9 opt-out to keep the explicit `kotlin-android` plugin; removal required before AGP 10 (per in-file comment) |
 | `android.newDsl` | `false` | **Temporary / must migrate** — AGP 9 new-DSL opt-out, same AGP 10 deadline |
 
-Root `gradle.properties` is git-tracked — never put secrets in it. As of 2026-07-06 it
-contains only the flags above (verified: no ALL_CAPS secret keys present).
+Root `gradle.properties` is git-tracked and NOT in `.gitignore`. The **committed** version
+contains only the flags above. ⚠️ **But as of 2026-07-27 the main checkout's working copy
+carries all 18 secrets as an uncommitted modification** — see "Where values live locally"
+below and **fromagerie-operations-hardening-frontier §4b**. Never `git add`, `git restore`,
+or `git checkout` this file: staging it leaks the SumUp and keystore credentials, reverting
+it destroys the only copy.
 
 ## google-services.json (Firebase config)
 
@@ -151,17 +155,36 @@ Facts verified 2026-07-06, updated 2026-07-07 (commit `ecda756`):
   the function's env. These are NOT Gradle keys — setting them in gradle.properties does
   nothing.
 
-## Where values live locally — as of 2026-07-06
+## Where values live locally — RESOLVED 2026-07-27 (supersedes the 2026-07-06 guess)
 
-Verified by existence-only checks on this machine: none of the Gradle keys above are
-present in the worktree `local.properties` (only `sdk.dir`), the root
-`gradle.properties`, or `~/.gradle/gradle.properties`, and none are exported in a
-non-interactive shell. UNVERIFIED: the exact supply mechanism on Tommy's machine —
-presumably the interactive shell profile or Android Studio's run environment exports
-them as env vars (the `System.getenv` branch). Consequence for agents: **a CLI Gradle
-build from a fresh non-interactive shell will bake `"null"` into every secret BuildConfig
-field** and cannot sign a release. Do not conclude "config is broken" from that alone;
-confirm with the wiring checks below and ask before touching anything.
+**The 18 secrets live in the MAIN CHECKOUT's root `gradle.properties`** —
+`/Users/tommy/StudioProjects/LaFromagerie/gradle.properties`, 58 lines, carrying
+`KEYSTORE_*`, `MAPBOX_*`, `SUMUP_*`, `GOOGLE_PAY_*`, `GOOGLE_API`, `OPEN_ROUTE_TOKEN`,
+`CLOUDINARY_*`. They are **not** env vars: `~/.gradle/gradle.properties` does not exist on
+this machine, and no shell profile exports them. The earlier "presumably the interactive
+shell profile or Android Studio" note was wrong — discard it.
+
+Two consequences that bite agents, both verified 2026-07-27:
+
+1. **Worktrees do not inherit them.** `gradle.properties` is a *tracked* file and the
+   secrets are an **uncommitted working-tree modification** in the main checkout. A
+   `git worktree` checkout therefore gets the committed, secret-free 26-line version, so
+   **every build from a `.claude/worktrees/*` session bakes `"null"` into every secret
+   BuildConfig field.** Symptoms: black Mapbox map, OpenRouteService
+   `Access to this API has been disallowed`, unsignable release. Do not conclude "the map
+   is broken" or "the API key expired" from a worktree build — check `BuildConfig` first:
+   ```
+   find delivery/presentation/build -name BuildConfig.java | xargs grep MAPBOX_PUBLIC_TOKEN
+   ```
+   To build a genuinely testable APK from a worktree, pass the values explicitly
+   (`-PMAPBOX_PUBLIC_TOKEN=… -POPEN_ROUTE_TOKEN=…`) or build from the main checkout /
+   Android Studio. Never ask Tommy to paste secret values into a session.
+
+2. **They are one `git add -A` from being published**, and one `git restore` from being
+   lost — `gradle.properties` is tracked and NOT in `.gitignore`. This is an open hardening
+   item with the full remediation sequence (rescue → move to `~/.gradle/gradle.properties`
+   → fail fast on `"null"`): **fromagerie-operations-hardening-frontier §4b**. Do not
+   "helpfully" `git add` or `git checkout` that file.
 
 ## Checklist — add a new secret/config axis correctly
 
@@ -270,6 +293,8 @@ facts with (run from repo root):
 | Backend tracked, `.env` still ignored | `git ls-files la-fromagerie-backend/functions` (expect source files) and `git check-ignore la-fromagerie-backend/functions/.env` (expect a match) |
 | Hardcoded function URL unchanged | `grep -n "createsumupcheckout" checkout/data/src/main/java/com/mtdevelopment/checkout/data/remote/source/SumUpDataSource.kt` |
 | local.properties still sdk.dir-only | `grep -o "^[A-Za-z._-]*=" local.properties` |
+| Secrets still in the tracked root gradle.properties (2026-07-27) | `git -C /Users/tommy/StudioProjects/LaFromagerie status --short gradle.properties` (expect ` M`) and `git ls-files --error-unmatch gradle.properties` (expect tracked) |
+| A worktree build baked `"null"` secrets | `find delivery/presentation/build -name BuildConfig.java \| xargs grep MAPBOX_PUBLIC_TOKEN` |
 
 If any command's output no longer matches this file, update the file — key names and
 line numbers here are load-bearing for other agents.

--- a/.claude/skills/fromagerie-operations-hardening-frontier/SKILL.md
+++ b/.claude/skills/fromagerie-operations-hardening-frontier/SKILL.md
@@ -10,8 +10,10 @@ description: >
   Items covered: payment-funnel observability gaps, hosted-checkout hardening (3 MAJOR
   TODOs, owner-confirmed 2026-07-07: missing safety net, single-shot verification,
   hardcoded URL/key-in-APK batch), backend versioning (RESOLVED 2026-07-07, README
-  residual), no admin auth, no CI, the 2 failing AdminViewModelTest tests, AGP 10
-  migration debt, delivery-day offline resilience, cart persistence / client notifications.
+  residual), no admin auth, secret handling (18 secrets in a TRACKED gradle.properties and
+  `"null"`-sentinel builds that pass silently, found 2026-07-27), no CI, the 2 failing
+  AdminViewModelTest tests, AGP 10 migration debt, delivery-day offline resilience, cart
+  persistence / client notifications.
 ---
 
 # LaFromagerie — Operations Hardening Frontier
@@ -50,6 +52,7 @@ real payment; all changes go via PR to main. See **fromagerie-change-control**.
 | 2 | Backend not in version control — ✅ resolved `ecda756` (2026-07-07), README residual | infra | ~~Server logic unrecoverable~~ — closed |
 | 3 | Delivery-day offline resilience | ops | Delivery day derailed by dead signal |
 | 4 | Admin auth — PIN gate LANDED 2026-07-08; hardened Firestore rules still undeployed | security | UI gated; DB still world-writable until rules ship |
+| 4b | **Secrets in a tracked `gradle.properties` + `"null"` builds pass silently** (§4b) | security / quality | One `git add -A` leaks SumUp + keystore keys; one `git restore` loses them |
 | 5 | No CI | quality | Broken flavor/tests reach main unnoticed |
 | 6 | 2 failing AdminViewModelTest tests | quality | Green baseline is a lie; masks regressions |
 | 7 | AGP 10 migration debt | infra | Future toolchain bump blocked |
@@ -191,6 +194,61 @@ roadmap entry so no session misses them.
   App-side milestone is met; rules milestone is not yet.
 - **Re-verify the gate exists:**
   `grep -rn 'PinLockScreen\|authViewModel' app/src/admin --include='*.kt' | grep -v /build/`
+
+## 4b. Secret handling — 18 secrets live in a TRACKED file, and `"null"` builds pass silently
+
+Discovered 2026-07-27 while diagnosing a black delivery map on an AI-built APK. Two distinct
+problems, one shared root: `gradle.properties`.
+
+- **Why it falls short — (a) the leak risk.** All 18 secrets (`SUMUP_PRIVATE_KEY`,
+  `KEYSTORE_PASS`, `KEYSTORE_ALIAS_PASS`, `CLOUDINARY_PRIVATE`, `MAPBOX_*`,
+  `GOOGLE_PAY_*`, `OPEN_ROUTE_TOKEN`, …) live in the **root `gradle.properties`**, which is
+  **tracked by git and absent from `.gitignore`**. They exist only as an *uncommitted
+  working-tree modification* (` M gradle.properties`). This is the worst of both worlds:
+  - one `git add -A` / `git commit -a` in the main repo publishes the SumUp private key and
+    the release-keystore passwords to a public GitHub repo;
+  - one `git restore`/`git stash`/`git clean` **destroys the only copy** — there is no
+    backup, and the release keystore becomes unusable if its passwords are lost.
+  Note the config skill previously asserted these lived in `~/.gradle/gradle.properties`;
+  that file **does not exist** on this machine. Corrected in **fromagerie-config-and-secrets**.
+- **Why it falls short — (b) the `"null"` sentinel.** Every secret is wired as
+  `buildConfigField("String", "X", "\"${System.getenv("X") ?: findProperty("X")}\"")`. When
+  the value is absent, Kotlin interpolates the **literal string `"null"`** — the build
+  **succeeds** and ships a silently broken APK. Observed symptoms: black Mapbox map
+  (`MapboxOptions.accessToken = "null"`), OpenRouteService `Access to this API has been
+  disallowed` (Bearer `"null"`). Nothing at build time says a word.
+- **The worktree multiplier:** `git worktree` checkouts get the **committed** (secret-free,
+  26-line) `gradle.properties`, not Tommy's 58-line local modification. So **every AI
+  worktree session builds token-less APKs by default** and any on-device map/routing check
+  from such a build is meaningless. This burned a real session (2026-07-27).
+- **Our leverage:** both fixes are small, local, and independent of prod. The env-var
+  fallback (`System.getenv`) already exists in every consumer, so moving the store is a
+  no-code change.
+- **First three steps:**
+  1. **Rescue the secrets first** (owner, before anything else): copy the 58-line
+     `gradle.properties` somewhere durable — a password manager entry or an encrypted note.
+     Everything below risks the working-tree copy.
+  2. **Move them out of the repo.** Create `~/.gradle/gradle.properties` with the 18 keys,
+     revert the root `gradle.properties` to its committed state. Gradle merges the user-home
+     file into every build, including worktrees — which fixes the worktree trap at the same
+     time. (Do NOT just add `gradle.properties` to `.gitignore`: it is already tracked, so
+     ignoring it does nothing until `git rm --cached` — and that would delete the shop's
+     build config for everyone.)
+  3. **Fail fast on `"null"`.** In each `build.gradle.kts` that declares a secret
+     `buildConfigField`, throw on a missing value for release builds and warn loudly for
+     debug — so a token-less APK is impossible to ship and obvious to spot locally.
+     Consumers: `delivery/presentation` (`MAPBOX_*`), `delivery/data` (`OPEN_ROUTE_TOKEN`),
+     `checkout/data` (`SUMUP_*`, `GOOGLE_PAY_*`), `core/data` (`CLOUDINARY_*`, `GOOGLE_API`).
+- **Result when…** (a) `git log -p -- gradle.properties` shows no secret ever committed AND
+  the working tree is clean because the values now live in `~/.gradle/gradle.properties`;
+  (b) a build with a secret unset **fails or warns audibly** instead of producing an APK
+  whose `BuildConfig` field is `"null"`; (c) a fresh worktree builds a working map with no
+  extra setup.
+- **Re-verify the exposure:**
+  `git ls-files --error-unmatch gradle.properties && git check-ignore -v gradle.properties; git status --short gradle.properties`
+- ⚠️ **If a secret was ever committed**, rotating it is the only real remedy (history
+  rewriting is not enough on a pushed public repo) — SumUp keys and the keystore passwords
+  first. Verify with `git log --oneline -S 'SUMUP_PRIVATE_KEY' -- gradle.properties`.
 
 ## 5. No CI
 


### PR DESCRIPTION
Docs only — aucun impact build. Complète #54 sans s'y mêler (change-control : une PR de bump de dépendance reste seule).

## Origine

En testant l'APK de #54 sur device, la carte de livraison était un bloc noir et OpenRouteService répondait `Access to this API has been disallowed`. Ce n'était **pas** une régression Mapbox 11.18 : l'APK avait été buildé depuis un worktree, et les trois tokens étaient la chaîne littérale `"null"`.

## Ce qui est documenté

Nouvel item **§4b** dans `fromagerie-operations-hardening-frontier` — deux problèmes, une même racine, `gradle.properties` :

**(a) Risque de fuite.** Les 18 secrets (`SUMUP_PRIVATE_KEY`, `KEYSTORE_PASS`, `KEYSTORE_ALIAS_PASS`, `CLOUDINARY_PRIVATE`, `MAPBOX_*`, `GOOGLE_PAY_*`…) vivent dans la `gradle.properties` racine, **trackée par git et absente du `.gitignore`**, sous forme de modification non commitée. Le pire des deux mondes :

- un `git add -A` publie la clé privée SumUp et les mots de passe du keystore sur un repo public ;
- un `git restore` / `git stash` / `git clean` **détruit l'unique copie** — pas de backup, et le keystore de release devient inutilisable si ses mots de passe sont perdus.

**(b) Le sentinel `"null"`.** `buildConfigField("String", "X", "\"${getenv("X") ?: findProperty("X")}\"")` interpole un `null` Kotlin en chaîne `"null"`. Le build **réussit** et livre un APK silencieusement cassé. Rien ne le signale.

**Le multiplicateur worktree.** Un `git worktree` récupère la version *commitée* (26 lignes, sans secrets), pas la modification locale de 58 lignes. Donc **toute session d'agent en worktree build des APK sans tokens**, et toute vérification carte/routing depuis un tel build ne vaut rien.

La séquence de remédiation est dans §4b : sauvegarder d'abord → déplacer vers `~/.gradle/gradle.properties` (que Gradle fusionne dans tous les builds, worktrees compris) → faire échouer le build sur `"null"`.

## Correction factuelle

`fromagerie-config-and-secrets` affirmait que les secrets venaient de variables d'environnement exportées par le profil shell ou Android Studio. C'est faux : `~/.gradle/gradle.properties` n'existe pas sur cette machine. Section réécrite, plus deux entrées dans la table de re-vérification.

## Note

Le point (a) mérite une décision rapide — pas parce que quelque chose a fuité (rien n'a été commité, vérifiable avec `git log --oneline -S 'SUMUP_PRIVATE_KEY' -- gradle.properties`), mais parce que l'état actuel est à un `git add -A` près de l'incident, et à un `git restore` près de la perte du keystore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)