### PR TITLE
Rebrand the app display name to "FromDeBique"

### DIFF
--- a/app/src/admin/java/com/mtdevelopment/lafromagerie/MainActivity.kt
+++ b/app/src/admin/java/com/mtdevelopment/lafromagerie/MainActivity.kt
@@ -210,7 +210,7 @@ class MainActivity : ComponentActivity() {
                                 scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer
                             ),
                             title = {
-                                Text("La Fromagerie")
+                                Text("FromDeBique")
                             },
                             navigationIcon = {
                                 AnimatedVisibility(

--- a/app/src/client/java/com/mtdevelopment/lafromagerie/MainActivity.kt
+++ b/app/src/client/java/com/mtdevelopment/lafromagerie/MainActivity.kt
@@ -224,7 +224,7 @@ class MainActivity : ComponentActivity() {
                                 scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer
                             ),
                             title = {
-                                Text("La Fromagerie")
+                                Text("FromDeBique")
                             },
                             navigationIcon = {
                                 // previousBackStackEntry is not snapshot state: it is re-read here

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">La Fromagerie</string>
+    <string name="app_name">FromDeBique</string>
     <string name="cart_content_description">Panier</string>
     <string name="loading_animation">Animation de chargement</string>
     <string name="error_database_update">Mise à jour de la base de donnée impossible</string>

--- a/auth/src/main/java/com/mtdevelopment/auth/presentation/screen/PinLockScreen.kt
+++ b/auth/src/main/java/com/mtdevelopment/auth/presentation/screen/PinLockScreen.kt
@@ -56,7 +56,7 @@ fun PinLockScreen(
             verticalArrangement = Arrangement.Center
         ) {
             Text(
-                text = "La Fromagerie",
+                text = "FromDeBique",
                 style = MaterialTheme.typography.headlineMedium,
                 color = MaterialTheme.colorScheme.onBackground
             )

--- a/la-fromagerie-backend/functions/src/billing.ts
+++ b/la-fromagerie-backend/functions/src/billing.ts
@@ -149,7 +149,7 @@ async function buildInvoiceLines(
 ): Promise<InvoiceLine[]> {
     const entries = Object.entries(products);
     const fallback: InvoiceLine[] = [
-        { description: `Commande La Fromagerie #${orderId}`, unitPriceCents: totalCents, quantity: 1 },
+        { description: `Commande FromDeBique #${orderId}`, unitPriceCents: totalCents, quantity: 1 },
     ];
     if (entries.length === 0) {
         return fallback;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,7 +40,7 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "La Fromagerie"
+rootProject.name = "FromDeBique"
 include(":app")
 include(":auth")
 include(":core")


### PR DESCRIPTION
## What changed

Display-name-only rebrand from "La Fromagerie" to "FromDeBique". Six one-line
changes, no logic touched.

**1. Launcher label and notification titles** (`app/src/main/res/values/strings.xml`)
`app_name` is what Android shows under the icon and uses as the default title for
notification channels.

**2. Top bar titles** (`app/src/client/.../MainActivity.kt`, `app/src/admin/.../MainActivity.kt`)
Each flavor hardcodes the title in its own `Scaffold`'s `TopAppBar`, so both needed the
same edit.

**3. Admin PIN lock header** (`auth/.../screen/PinLockScreen.kt`)
The headline above "Entrez le code d'accès".

**4. SumUp invoice fallback line** (`la-fromagerie-backend/functions/src/billing.ts`)
`buildInvoiceLines()`'s fallback description, used when an order has no resolvable
products. This one is **customer-visible on the SumUp receipt** and only takes effect
after `firebase deploy --only functions` — **not deployed by this PR**.

**5. `rootProject.name`** (`settings.gradle.kts`)
Cosmetic; changes the project name shown in the IDE. Nothing reads it.

## Why

"La Fromagerie" is generic. The brand is FromDeBique.

Scoped deliberately to the *visible* layer. The `applicationId`
(`com.mtdevelopment.lafromagerie`), the Kotlin package and the
`lafromagerie://checkout-callback` scheme are **unchanged** — the app is currently in
Play review, and a new `applicationId` would mean a new Console entry, a review
restarted from zero, a permanently burned package name and invalidated FCM tokens, all
for an identifier no customer ever reads. Touching the deep-link scheme would
additionally drag the payment chain into a UI/copy change and force an app+backend
lockstep deploy, for zero visible benefit.

Not in scope, both needing a decision outside this repo: the Play Console listing name
(freely editable at any time, including mid-review) and the launcher icon / splash
assets.

## Verification

Verified on the build host, both flavors:

- `./gradlew assembleClientDebug assembleAdminDebug` → **BUILD SUCCESSFUL in 1m 10s**,
  996 actionable tasks.
- `aapt2 dump badging app-client-debug.apk` → `application-label:'FromDeBique'` (and on
  all 90 locale-qualified label variants), while `package:` still reads
  `name='com.mtdevelopment.lafromagerie' versionCode='13' versionName='1.9.0-client'` —
  confirming the label changed in the packaged APK and the applicationId did not.
- `grep -rIn "La Fromagerie"` across the repo, excluding `build/`, `.git/` and docs,
  returns only two hits, both KDoc/comments in
  `admin/data/.../GoogleRouteDataSource.kt:32,74`. Those name the **physical farm** whose
  postal address (`HOME_BASE_ADDRESS = "8 La Vessoye, 25560 Boujailles"`) anchors every
  optimized delivery route — not the app. Left as-is; renaming the shop is a separate
  decision.
- No test asserted on the old string (same grep covers test sources), so no suite
  changes were required. The 2 known-failing `AdminViewModelTest` tests at HEAD are
  untouched by this change.

## Follow-ups

- [x] `firebase deploy --only functions` to activate the invoice label (production —
      left for the owner).
- [ ] Rename the Play Console listing.
- [ ] Optional, low value: centralize the three now-duplicated literals behind
      `stringResource(R.string.app_name)`. `:auth` has no `strings.xml` of its own, so it
      would need one — deliberately excluded here to keep this diff a pure rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
