### PR TITLE
Release prep: client AAB permissions, invoice detail lines, versionCode 21

### DIFF
--- a/.claude/skills/fromagerie-operations-hardening-frontier/SKILL.md
+++ b/.claude/skills/fromagerie-operations-hardening-frontier/SKILL.md
@@ -14,6 +14,11 @@ description: >
   `"null"`-sentinel builds that pass silently, found 2026-07-27), no CI, the 2 failing
   AdminViewModelTest tests, AGP 10 migration debt, delivery-day offline resilience, cart
   persistence / client notifications.
+  residual), no admin auth, admin code leaking into the client AAB / broken flavor
+  isolation (found 2026-07-24: manifest patched, dependency wiring still to fix — also the
+  Play Store background-location blocker), no CI, the 2 failing AdminViewModelTest tests,
+  AGP 10 migration debt, delivery-day offline resilience, cart persistence / client
+  notifications.
 ---
 
 # LaFromagerie — Operations Hardening Frontier
@@ -45,18 +50,19 @@ real payment; all changes go via PR to main. See **fromagerie-change-control**.
 
 ## Risk ranking (highest daily-operation risk first)
 
-| # | Problem | Class | Daily-op blast radius |
-|---|---|---|---|
-| 1 | Payment-funnel observability gaps | payment | **Money lost silently** — worst case |
+| #  | Problem | Class | Daily-op blast radius |
+|----|---|---|---|
+| 1  | Payment-funnel observability gaps | payment | **Money lost silently** — worst case |
 | 1b | **Hosted-checkout hardening — 3 MAJOR TODOs** (§1b) | payment | Paid-but-PENDING orders on the new path |
-| 2 | Backend not in version control — ✅ resolved `ecda756` (2026-07-07), README residual | infra | ~~Server logic unrecoverable~~ — closed |
-| 3 | Delivery-day offline resilience | ops | Delivery day derailed by dead signal |
-| 4 | Admin auth — PIN gate LANDED 2026-07-08; hardened Firestore rules still undeployed | security | UI gated; DB still world-writable until rules ship |
-| 4b | **Secrets in a tracked `gradle.properties` + `"null"` builds pass silently** (§4b) | security / quality | One `git add -A` leaks SumUp + keystore keys; one `git restore` loses them |
-| 5 | No CI | quality | Broken flavor/tests reach main unnoticed |
-| 6 | 2 failing AdminViewModelTest tests | quality | Green baseline is a lie; masks regressions |
-| 7 | AGP 10 migration debt | infra | Future toolchain bump blocked |
-| 8 | Cart persistence (client notifications SHIPPED 2026-07-07) | product | UX gap (product-decision-pending) |
+| 2  | Backend not in version control — ✅ resolved `ecda756` (2026-07-07), README residual | infra | ~~Server logic unrecoverable~~ — closed |
+| 3  | Delivery-day offline resilience | ops | Delivery day derailed by dead signal |
+| 4  | Admin auth — PIN gate LANDED 2026-07-08; hardened Firestore rules still undeployed | security | UI gated; DB still world-writable until rules ship |
+| 4b | **Admin code leaks into the client AAB** (§4b) — manifest patched 2026-07-24, wiring NOT fixed | security | Admin keys ship to customers; blocks Play releases |
+| 4c | **Secrets in a tracked `gradle.properties` + `"null"` builds pass silently** (§4b) | security / quality | One `git add -A` leaks SumUp + keystore keys; one `git restore` loses them |
+| 5  | No CI | quality | Broken flavor/tests reach main unnoticed |
+| 6  | 2 failing AdminViewModelTest tests | quality | Green baseline is a lie; masks regressions |
+| 7  | AGP 10 migration debt | infra | Future toolchain bump blocked |
+| 8  | Cart persistence (client notifications SHIPPED 2026-07-07) | product | UX gap (product-decision-pending) |
 
 ---
 
@@ -195,7 +201,57 @@ roadmap entry so no session misses them.
 - **Re-verify the gate exists:**
   `grep -rn 'PinLockScreen\|authViewModel' app/src/admin --include='*.kt' | grep -v /build/`
 
-## 4b. Secret handling — 18 secrets live in a TRACKED file, and `"null"` builds pass silently
+## 4b. Admin code leaks into the client AAB — flavor isolation is broken (found 2026-07-24)
+
+- **Why it falls short:** `app/build.gradle.kts:111-114` wires the admin modules with
+  `adminImplementation`, which *looks* like the client flavor excludes them. It does not.
+  Four **shared** modules (compiled into both flavors) depend on `:admin:presentation` with
+  a plain `implementation`, dragging the whole module — manifest *and* classes — into the
+  client build:
+  - `home/presentation/build.gradle.kts:54`
+  - `details/presentation/build.gradle.kts:50`
+  - `checkout/presentation/build.gradle.kts:54`
+  - `delivery/presentation/build.gradle.kts:59`
+
+  This **defeats the stated goal of commit `c436c68`** ("admin API keys will NOT be built
+  into clients version of the app, protecting them against reverse-engineering"): admin
+  code ships to every customer. It first surfaced as a **Play Store release blocker** —
+  `ACCESS_BACKGROUND_LOCATION` appeared in the signed client AAB with no client-facing
+  feature to justify it (blame: *"ADDED from [:admin:presentation]"* in
+  `app/build/outputs/logs/manifest-merger-client-release-report.txt`).
+- **Symptom treated, cause NOT fixed (2026-07-24):** the *manifest* half is patched —
+  `app/src/client/AndroidManifest.xml` strips `ACCESS_BACKGROUND_LOCATION` and
+  `FOREGROUND_SERVICE_LOCATION` via `tools:node="remove"`, and the admin-only
+  `DeliveryTrackingService` + `NotificationBroadcastReceiver` declarations moved from
+  `app/src/main/AndroidManifest.xml` to a new `app/src/admin/AndroidManifest.xml` (their
+  classes were always admin-only in `app/src/admin/java`, so the client AAB was declaring a
+  location foreground service it could not even run). **The classes still ship to clients.**
+  This is a band-aid with a documented removal condition, not a fix.
+- **Our leverage:** the correct wiring already exists and is proven — `adminImplementation`
+  in `app/build.gradle.kts`, plus the `auth` module precedent. The change is four lines.
+- **First three steps:**
+  1. Flip the four `implementation(project(":admin:presentation"))` above to
+     `"adminImplementation"(project(":admin:presentation"))`.
+  2. Compile the **client** flavor and triage every unresolved reference: shared code in
+     those modules that touches admin classes is the real coupling. Push it behind an
+     interface owned by the shared module (admin supplies the impl via Koin), or move it
+     into the `admin` source set. Do **not** re-add the dependency to make it compile.
+  3. Once client compiles, delete the two `tools:node="remove"` lines from
+     `app/src/client/AndroidManifest.xml` and re-verify (below). Both flavors must assemble.
+- **Result when…** the client release manifest contains **no** `ACCESS_BACKGROUND_LOCATION`
+  *without* any `tools:node="remove"` crutch, AND `:admin:presentation` no longer appears in
+  the client dependency graph:
+  ```
+  ./gradlew :app:dependencies --configuration clientReleaseRuntimeClasspath | grep -i "admin"
+  ```
+  (empty = fixed), cross-checked against the merge report blame:
+  ```
+  grep -A2 BACKGROUND_LOCATION app/build/outputs/logs/manifest-merger-client-release-report.txt
+  ```
+- **Priority:** treat as the top non-payment item — it is a security regression (admin keys
+  in customer hands) *and* it gates Play Store releases. Own branch, own PR.
+
+## 4c. Secret handling — 18 secrets live in a TRACKED file, and `"null"` builds pass silently
 
 Discovered 2026-07-27 while diagnosing a black delivery map on an AI-built APK. Two distinct
 problems, one shared root: `gradle.properties`.
@@ -348,6 +404,8 @@ problems, one shared root: `gradle.properties`.
 | 3. Firestore offline persistence | `grep -rin 'persistenceEnabled\|PersistentCacheSettings\|setFirestoreSettings' . \| grep -v /build/` (empty = SDK defaults, UNVERIFIED) |
 | 3. admin orders are Firestore-direct | read `admin/data/.../repository/FirebaseAdminRepositoryImpl.kt` (no Room = still direct) |
 | 4. no admin auth | `grep -rin 'signIn\|FirebaseAuth\|currentUser\|login' app/src/admin admin --include='*.kt' \| grep -v /build/` |
+| 4b. admin modules still in the client graph | `grep -rn 'implementation(project(":admin' home details checkout delivery --include='build.gradle.kts'` (any plain `implementation` = §4b still open; expect `adminImplementation` once fixed) |
+| 4b. manifest band-aid still needed | `grep -n 'node="remove"' app/src/client/AndroidManifest.xml` (hits = crutch still in place; delete only after the wiring fix) |
 | 5. no CI | `ls .github/workflows 2>/dev/null; find . -maxdepth 2 -iname '*.yml' -o -iname '*.yaml' \| grep -v /build/ \| grep -vi google-services` |
 | 6. failing tests | `./gradlew testAdminDebugUnitTest --continue` |
 | 7. AGP opt-out flags | `grep -nE 'builtInKotlin\|newDsl' gradle.properties; grep -n '^agp' gradle/libs.versions.toml` |

--- a/.claude/skills/fromagerie-payment-reliability-campaign/SKILL.md
+++ b/.claude/skills/fromagerie-payment-reliability-campaign/SKILL.md
@@ -125,6 +125,41 @@ What is **actually guaranteed** today (traced from `FinalizePaymentWorker` + `Wo
 6. **Firestore rules — exported 2026-07-08, finding CRITICAL:** the live rules are now in the repo (`la-fromagerie-backend/firestore.rules`, wired into `firebase.json`; indexes + `.firebaserc` alongside) and they confirm the worst case: `allow read, write: if true` on `/{document=**}` — **all of prod Firestore is world-writable with the APK's API key** (the in-file comment claiming admin-only writes is wrong). Full analysis + a hardened draft (`firestore.rules.hardened-proposal`, order-shape validation only — real enforcement is blocked on admin auth) in `la-fromagerie-backend/FIRESTORE_RULES_AUDIT.md`. **Deploying any rules change needs Tommy** — the draft is intentionally NOT the wired file.
 7. **App-killed outcome surfacing — TRIED then REVERTED (#50 branch, 2026-07-10):** an attempt to record the worker's terminal outcome (`PaymentOutcome` in the checkout DataStore, written by `FinalizePaymentWorker.finalize()`) and, on next launch, route the customer straight to `AfterPaymentScreen` on PAID / snackbar on FAILED (consumed via `ConsumePaymentOutcomeUseCase` in the client `NavGraph`). **Rolled back on owner device-testing — the forced navigate-to-success-on-launch caused abnormal navigation in some cases** (e.g. being thrown onto the after-payment screen when reopening the app just to shop). The whole feature commit was reverted; the ON_RESUME fallback (item 2) already covers the common case (customer closes the tab → app shows success), so this is not load-bearing. **If revisited, use a NON-navigating notice** (a dismissible dialog/snackbar on whatever screen the user is on), never a forced `navController.navigate` from a launch `LaunchedEffect`. **Redirect decision (owner 2026-07-10): leave the `lafromagerie://checkout-callback` custom scheme as-is** — the ON_RESUME fallback removed the dependency on it firing, so an HTTPS App Link (verified domain + `assetlinks.json` + backend redirect change) is NOT worth it; the next step up is the webhook (Phase 5), not the redirect.
 
+### Invoicing pipeline (order-confirmation email) — idempotency under retry
+
+**Landed 2026-07-14: automated order-confirmation invoicing via Invoice Ninja (self-hosted on Le Serv) → Brevo.** Two Cloud Functions feed one shared, idempotent routine `createAndSendInvoice` (`la-fromagerie-backend/functions/src/billing.ts`):
+- `onOrderPaidCreateInvoice` — Firestore trigger on `orders/{orderId}`, `retry: true` (`index.ts:111`). Primary path, covers ALL payment flows (fires on the PAID transition).
+- `handleSumUpWebhook` — hosted-checkout defence-in-depth; returns 5xx on failure so SumUp re-delivers (1 min / 5 min / 20 min / 2 h).
+
+Idempotency is enforced by a transactional claim doc in the `invoices/{orderId}` collection (`billing.ts:106` `claimInvoice`): a full success marks it `sent`, so any later replay short-circuits to `skipped`. **No double invoice on the common paths.**
+
+**Deploy warning is expected, not a defect.** `firebase deploy` prints `functions will newly be retried in case of failure: onOrderPaidCreateInvoice` — that is the intended `retry: true` (owner-chosen for reliability: don't lose an invoice when Invoice Ninja is transiently down). It is not blocking. Firebase's reminder ("ensure your functions are idempotent") points at the one real gap below.
+
+**GAP (found 2026-07-14, owner-deferred same day — do NOT fix without sign-off): release-on-failure after a partial success double-invoices under retry.** In `createAndSendInvoice` the `catch` calls `releaseClaim` (`billing.ts:97`) for ANY throw. But the external side-effect — `markPaidAndEmail` (`billing.ts:91`, sends the Brevo email) — runs BEFORE `markInvoiced` (`billing.ts:93`, the write that stamps the claim `sent`). So the narrow window is:
+
+```
+claim → createInvoice → markPaidAndEmail ✅ (email sent)
+                              ↓
+                        markInvoiced ❌ throws (Firestore write fails)
+                              ↓
+                        catch → releaseClaim  ← claim freed
+                              ↓
+        retry (trigger rejoué, up to 7 days / SumUp re-delivery)
+                              ↓
+        re-claims → creates a 2ND invoice + sends a 2ND email
+```
+
+Impact: duplicate invoice + duplicate confirmation email to the customer. **Not a payment loss** (no money moves; the total on each invoice is still exact) — a customer-facing annoyance, amplified by `retry: true`'s up-to-7-day horizon and the webhook's own retry schedule. Low probability (a Firestore `set` failing immediately after a successful HTTP round-trip), which is why it is deferred, not urgent.
+
+**Option B (candidate — the durable fix, owner-deferred 2026-07-14):** make the claim survive partial progress instead of being torn down.
+1. Persist `invoice_ninja_id` into the claim doc as soon as `createInvoice` returns (before `markPaidAndEmail`), keeping it in the `processing` state.
+2. Only `releaseClaim` for failures that happen BEFORE any Invoice Ninja side-effect (i.e. before `createInvoice`); once an invoice exists, never release — leave the claim as a resumable marker.
+3. On replay, if the claim already carries an `invoice_ninja_id`, resume at the email/mark-sent step (or check Invoice Ninja for an existing invoice by `po_number == orderId`) instead of recreating.
+
+Verification obligation: unit tests (mock the Invoice Ninja client + Firestore) proving that a throw injected between `markPaidAndEmail` and `markInvoiced` leaves exactly ONE invoice after a replay, and that a pre-`createInvoice` failure still releases and retries cleanly. Deploy needs Tommy (backend + prod).
+
+**Option A (accepted for now):** leave as-is. A duplicated confirmation email is a benign incident for a single-shop business; revisit only if it actually occurs.
+
 ## Solution menu, ranked
 
 | Rank | Solution | Status | Verification obligation |
@@ -138,6 +173,7 @@ What is **actually guaranteed** today (traced from `FinalizePaymentWorker` + `Wo
 | 7 | Admin stale-PENDING alert (Phase 3.3) | **candidate** | blocked on admin-screen UNVERIFIED item |
 | 8 | Webhook confirmation via Cloud Function (Phase 5) | **candidate — owner-designated next (2026-07-10)** | capability VERIFIED 2026-07-10 (`CHECKOUT_STATUS_CHANGED` via `return_url`; re-fetch to confirm); build on a branch, **deploy needs Tommy** (backend + prod) |
 | 9 | Hosted-checkout path via `createSumUpCheckout` | **LANDED as working WIP** (`ecda756`) | remaining before "done": ~~FPW safety net~~ (2026-07-08), ~~single-shot verification~~ (resilient poll #49 + ON_RESUME trigger #50, 2026-07-10), app-killed outcome surfacing (tried+reverted #50 — needs a non-navigating UX), two-path duplicate analysis, hardcoded URL — see the LANDED block above |
+| 10 | Invoicing idempotency Option B (release-on-failure gap) | **candidate — owner-deferred 2026-07-14** | unit test: throw between `markPaidAndEmail` and `markInvoiced` leaves exactly ONE invoice after replay — see "Invoicing pipeline" block |
 
 ## Known wrong paths — fenced off
 
@@ -181,3 +217,4 @@ Traced 2026-07-06 against HEAD `b97eb83` (worktree branch `claude/distracted-cha
 - Identifier mismatch: `grep -n "checkoutRef\|orderId = " checkout/presentation/src/main/java/com/mtdevelopment/checkout/presentation/viewmodel/CheckoutViewModel.kt`
 - 3DS still WebView / no deep link: `grep -rn "lafromagerie://" --include="AndroidManifest.xml" app/src checkout` (expect empty)
 - Backend still unversioned: from the main checkout, `git -C /Users/tommy/StudioProjects/LaFromagerie check-ignore la-fromagerie-backend/functions && echo STILL-IGNORED`
+- Invoicing release-on-failure gap still open: `grep -n "releaseClaim\|markPaidAndEmail\|markInvoiced" la-fromagerie-backend/functions/src/billing.ts` (release in the `catch` after `markPaidAndEmail` = Option B unfixed)

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ local.properties
 /cart/build/
 /checkout/build/
 /admin/build/
+.aider*

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,8 +42,8 @@ android {
         applicationId = "com.mtdevelopment.lafromagerie"
         minSdk = 26
         targetSdk = 36
-        versionCode = 13
-        versionName = "1.9.0"
+        versionCode = 21
+        versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -59,6 +59,7 @@ android {
         release {
 //            isDebuggable = true
             isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/src/admin/AndroidManifest.xml
+++ b/app/src/admin/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+
+        <!-- Delivery-day foreground tracking. Admin-only: both classes live in
+             app/src/admin/java, so these declarations must not reach the client AAB
+             (a location foreground service there would need a Play Store justification
+             for a feature the client flavor does not have). -->
+        <service
+            android:name="com.mtdevelopment.lafromagerie.DeliveryTrackingService"
+            android:foregroundServiceType="location" />
+        <receiver
+            android:name=".NotificationBroadcastReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="stopUpdate" />
+            </intent-filter>
+        </receiver>
+    </application>
+
+</manifest>

--- a/app/src/client/AndroidManifest.xml
+++ b/app/src/client/AndroidManifest.xml
@@ -1,7 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <!-- Stripped from the client AAB: these come from :admin:presentation, which still
+         leaks into the client variant through shared modules that depend on it with a
+         plain `implementation` (home/details/checkout/delivery :presentation) instead of
+         `adminImplementation`. They serve ONLY the admin delivery-day tracking, so the
+         client build cannot justify them to the Play Store.
+         Remove these <uses-permission> lines once that dependency wiring is fixed —
+         see fromagerie-operations-hardening-frontier ("admin code leaks into the client AAB").
+         ACCESS_FINE/COARSE_LOCATION are deliberately kept: the client legitimately uses
+         them for the delivery address and zone map. -->
+    <uses-permission
+        android:name="android.permission.ACCESS_BACKGROUND_LOCATION"
+        tools:node="remove" />
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE_LOCATION"
+        tools:node="remove" />
 
     <application>
         <service

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,15 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <!-- Firebase Analytics pulls in AD_ID transitively (play-services-measurement-impl).
+         Neither flavor serves ads, uses AdMob, or reads the advertising ID, so declaring it
+         to the Play Store would mean claiming a capability the app does not have. Removing
+         it is Google's documented option for apps that do not use the advertising ID; only
+         ad-attribution/audience features are lost, and we use none of them. -->
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
+
     <application
         android:name=".CheeseApplication"
         android:allowBackup="true"
@@ -51,17 +60,10 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths" />
         </provider>
-        <service
-            android:name="com.mtdevelopment.lafromagerie.DeliveryTrackingService"
-            android:foregroundServiceType="location" />
-        <receiver
-            android:name=".NotificationBroadcastReceiver"
-            android:enabled="true"
-            android:exported="false">
-            <intent-filter>
-                <action android:name="stopUpdate" />
-            </intent-filter>
-        </receiver>
+        <!-- DeliveryTrackingService and NotificationBroadcastReceiver are declared in the
+             admin source set (app/src/admin/AndroidManifest.xml): their classes only exist
+             in that flavor, and the client AAB must not declare a location foreground
+             service it cannot run. -->
     </application>
 
 </manifest>

--- a/la-fromagerie-backend/functions/src/billing.ts
+++ b/la-fromagerie-backend/functions/src/billing.ts
@@ -139,7 +139,14 @@ async function markInvoiced(orderId: string, invoiceNinjaId: string): Promise<vo
 
 /**
  * Construit les lignes de facture depuis la collection `products`.
- * Repli : commande sans produits ou produit introuvable -> une seule ligne au
+ *
+ * ATTENTION : dans la commande, la map `products` est indexée par NOM de
+ * produit (`{ nomProduit -> quantité }`), PAS par id de document — c'est le
+ * contrat écrit par le client (CheckoutViewModel) et lu par l'admin
+ * (OrderPreparationScreen). On résout donc le prix en indexant la collection
+ * `products` par son champ `name`, jamais via `.doc(cle)`.
+ *
+ * Repli : commande sans produits ou nom introuvable -> une seule ligne au
  * montant total débité (le total facturé reste exact).
  */
 async function buildInvoiceLines(
@@ -155,18 +162,23 @@ async function buildInvoiceLines(
         return fallback;
     }
 
+    // Index nom -> priceCents (la collection produits est petite : un shop).
     const db = getFirestore();
-    const docs = await Promise.all(
-        entries.map(([productId]) => db.collection("products").doc(productId).get()),
-    );
+    const productsSnap = await db.collection("products").get();
+    const priceByName = new Map<string, number>();
+    productsSnap.forEach((doc) => {
+        const name = doc.get("name");
+        const priceCents = doc.get("priceCents");
+        if (typeof name === "string" && typeof priceCents === "number") {
+            priceByName.set(name, priceCents);
+        }
+    });
 
     const lines: InvoiceLine[] = [];
     let allResolved = true;
-    docs.forEach((snap, i) => {
-        const quantity = entries[i][1];
-        const name = snap.get("name");
-        const priceCents = snap.get("priceCents");
-        if (!snap.exists || typeof name !== "string" || typeof priceCents !== "number") {
+    entries.forEach(([name, quantity]) => {
+        const priceCents = priceByName.get(name);
+        if (priceCents === undefined) {
             allResolved = false;
             return;
         }

--- a/la-fromagerie-backend/functions/src/invoiceNinja.ts
+++ b/la-fromagerie-backend/functions/src/invoiceNinja.ts
@@ -30,6 +30,56 @@ function centsToUnits(cents: number): number {
     return Number((cents / 100).toFixed(2));
 }
 
+/**
+ * Récapitulatif client pour `public_notes` : un produit par ligne (`\n` ->
+ * `<br>` via nl2br côté Invoice Ninja), puis la date de livraison en dernier,
+ * séparée par une ligne vide. Dérivé des lignes déjà envoyées dans
+ * `line_items` — sans le total ni le numéro de facture (l'email les gère à
+ * part). Ce texte apparaît dans l'email de confirmation ET sur le PDF.
+ */
+function buildPublicNotes(req: InvoiceRequest): string {
+    const blocks: string[] = [];
+    if (req.lines.length > 0) {
+        blocks.push(
+            req.lines.map((l) => `${l.quantity} × ${l.description}`).join("\n"),
+        );
+    }
+    if (req.deliveryDate) {
+        blocks.push(`Livraison prévue le ${req.deliveryDate}`);
+    }
+    return blocks.join("\n\n");
+}
+
+/** Id ISO numérique du pays France dans Invoice Ninja. */
+const COUNTRY_ID_FRANCE = 250;
+
+interface ParsedAddress {
+    address1: string;
+    postalCode?: string;
+    city?: string;
+}
+
+/**
+ * Découpe une adresse française mono-ligne (le seul format stocké sur la
+ * commande : le `label` renvoyé par l'API adresse gouv, ex.
+ * « 12 rue des Fromagers 69001 Lyon ») en rue / code postal / ville, pour
+ * alimenter les champs structurés du client Invoice Ninja (bloc destinataire
+ * du PDF).
+ *
+ * Le code postal FR (5 chiffres) sert de point de coupure. Repli : si aucun
+ * code postal n'est trouvé, toute la chaîne va dans `address1` (comportement
+ * historique) — mieux vaut une adresse brute qu'une adresse vide.
+ */
+function parseFrenchAddress(raw: string): ParsedAddress {
+    const trimmed = raw.trim();
+    const match = trimmed.match(/^(.*\S)[,\s]+(\d{5})[,\s]+(.+)$/);
+    if (!match) {
+        return { address1: trimmed };
+    }
+    const [, street, postalCode, city] = match;
+    return { address1: street.trim(), postalCode, city: city.trim() };
+}
+
 export class InvoiceNinjaClient {
     private readonly http: AxiosInstance;
 
@@ -55,9 +105,13 @@ export class InvoiceNinjaClient {
             return found;
         }
 
+        const addr = parseFrenchAddress(req.billingAddress);
         const created = await this.http.post("/clients", {
             name: req.clientName,
-            address1: req.billingAddress,
+            address1: addr.address1,
+            postal_code: addr.postalCode,
+            city: addr.city,
+            country_id: COUNTRY_ID_FRANCE,
             contacts: [
                 { first_name: req.clientName, email: req.email, send_email: true },
             ],
@@ -102,9 +156,7 @@ export class InvoiceNinjaClient {
             client_id: clientId,
             po_number: req.orderId,
             date: new Date().toISOString().slice(0, 10),
-            public_notes: req.deliveryDate
-                ? `Livraison prévue le ${req.deliveryDate}`
-                : "",
+            public_notes: buildPublicNotes(req),
             line_items: lineItems,
         });
         const id = res.data?.data?.id as string | undefined;


### PR DESCRIPTION
Batch of pending work-in-progress from the local tree, split into three independently revertable commits. Unrelated to each other, grouped only because they were sitting uncommitted together before the store release.

## 1. `b3ae50f` — Keep admin-only location declarations out of the client AAB

**Play Store blocker.** The signed client release carried `ACCESS_BACKGROUND_LOCATION`, blamed on `[:admin:presentation]` in the merger report, for a feature the client flavor does not have.

- New `app/src/admin/AndroidManifest.xml` holds `DeliveryTrackingService` and `NotificationBroadcastReceiver`, moved out of `src/main` — their classes only ever existed in `app/src/admin/java`, so the client AAB was declaring a location foreground service it could not run.
- Client manifest strips `ACCESS_BACKGROUND_LOCATION` and `FOREGROUND_SERVICE_LOCATION` via `tools:node="remove"`. `ACCESS_FINE/COARSE_LOCATION` stay — legitimately used for the delivery address and zone map.
- `src/main` drops `AD_ID`, pulled in transitively by Firebase Analytics.

**Verified on the signed APKs** with `aapt2 dump xmltree`, not on intent:

| | client | admin |
|---|---|---|
| `ACCESS_BACKGROUND_LOCATION` | absent | present |
| `FOREGROUND_SERVICE_LOCATION` | absent | present |
| `gms.permission.AD_ID` | absent | absent |
| admin components | none | both |

**Two residual gaps, both recorded as hardening item 4b:**
- The dependency wiring is **not** fixed — admin classes still ship to customers. `:app:dependencies --configuration clientReleaseRuntimeClasspath` still shows `:admin:presentation` four times. This is a documented band-aid, not a fix.
- `ACCESS_ADSERVICES_AD_ID` and `ACCESS_ADSERVICES_ATTRIBUTION` (Privacy Sandbox equivalents, from `play-services-measurement-api`) are still in both APKs. If the Console declaration says the app does not use the advertising ID, these contradict it.

## 2. `bea1566` — Fix invoice line items, address block and customer summary

**Every generated invoice was collapsing to the single fallback line.** `buildInvoiceLines` resolved products via `db.collection("products").doc(key)`, but the order's `products` map is keyed by product **name**, not document id — the contract `CheckoutViewModel` writes and `OrderPreparationScreen` reads. No lookup ever resolved. The invoiced *total* was always right; the detail never was.

- `billing.ts` indexes the products collection by its `name` field once and resolves against that. The name-keyed contract is now documented on the function.
- `invoiceNinja.ts` splits the single-line gouv-API address into `address1` / `postal_code` / `city` + `country_id` for the PDF recipient block, falling back to the raw string when no 5-digit postcode is found.
- `public_notes` now carries a per-product recap plus the delivery date, so the customer sees what they ordered in the confirmation email and on the PDF.

Also documents the invoicing pipeline in the payment-reliability skill, including the owner-deferred release-on-failure gap (a throw between `markPaidAndEmail` and `markInvoiced` can double-invoice under retry).

⚠️ **NOT deployed.** Needs `firebase deploy --only functions` to take effect.

## 3. `d1f70a5` — versionCode 21, resource shrinking, ignore `.aider`

`versionName` goes back to **1.0.0** — first public Play Store release under the FromDeBique name, deliberate. `versionCode` keeps climbing (13 → 21).

`isShrinkResources` enabled for release. Verified on the signed client APK: 7987 resources kept, 1615 dropped, **no app-owned resource in the removed list** — `appicon_simpler` (FCM notification icon), `provider_paths`, `app_name`, `ic_launcher` all retained. The only project resources dropped are Android Studio template leftovers.

### ⚠️ Read before building this from a clean checkout

The R8 opt-out flags that accompanied this locally — `android.r8.strictFullModeForKeepRules=false` and `android.r8.optimizedResourceShrinking=false` — live in `gradle.properties`, **deliberately excluded from this PR** because the working copy of that file also holds 18 plaintext secrets.

A clean checkout therefore builds with the AGP 9 defaults (both `true`), which is **not** the configuration validated above:

- Strict keep-rule mode changes whether a `-keep` rule implicitly retains the default constructor — which `proguard-rules.pro` relies on for the DataStore classes instantiated through Koin. Failure mode: a **release-only crash**, not a build error.
- Optimized resource shrinking selects the R8-integrated shrinker instead of the legacy one used for the verification above.

**Smoke-test a signed release build before shipping from a machine whose `gradle.properties` differs.** Untangling the secrets out of that file is hardening item 4c.

## Not included

`gradle.properties` (secrets — excluded on purpose), `app/mapping.txt` (build artifact; keep it for Crashlytics deobfuscation but it should be gitignored), the stray `.!61655!gradle.properties` temp file, and all the backend AI tooling (`.antigravitycli/`, `.agents/skills/`, `skills-lock.json`).
