### PR TITLE
Règles de résolution des parcours : choix client quand plusieurs tournées desservent l'adresse

### DIFF
--- a/delivery/domain/src/main/java/com/mtdevelopment/delivery/domain/usecase/BuildSelectableDeliveryDatesUseCase.kt
+++ b/delivery/domain/src/main/java/com/mtdevelopment/delivery/domain/usecase/BuildSelectableDeliveryDatesUseCase.kt
@@ -1,0 +1,114 @@
+package com.mtdevelopment.delivery.domain.usecase
+
+import com.mtdevelopment.delivery.domain.model.DeliveryPath
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.WeekFields
+import java.util.Locale
+
+/**
+ * One delivery date the customer may pick, and the tournée that would serve it.
+ *
+ * @property pathId Path the date belongs to. The customer picking a date is how they pick a path
+ *   when several tournées serve their address; nothing else records the choice.
+ * @property isPastDeadline The order window closed (see [ORDER_CUTOFF_HOUR]). The date is still
+ *   listed — hiding it would make the list silently shift and look like a bug — but it cannot be
+ *   selected.
+ */
+data class SelectableDeliveryDate(
+    val date: LocalDate,
+    val pathId: String,
+    val pathName: String,
+    val isPastDeadline: Boolean
+)
+
+/** Orders close the day before delivery, at noon. */
+const val ORDER_CUTOFF_HOUR = 12
+
+/** Day used when a path carries a [DeliveryPath.deliveryDay] that does not parse. */
+private val FALLBACK_DELIVERY_DAY = DayOfWeek.FRIDAY
+
+/**
+ * How far ahead to scan for occurrences before giving up. A biweekly path needs eight weeks to
+ * yield four dates; this bound only exists so a nonsense frequency cannot spin forever.
+ */
+private const val MAX_DAYS_SCANNED = 365
+
+/**
+ * Builds the delivery dates offered to a customer, merged across every path that serves them.
+ *
+ * Extracted from the date-picker Composable, where it was unreachable by tests: the week-parity
+ * arithmetic and the cut-off are the kind of rules that decide whether a real order is deliverable,
+ * so they belong here.
+ *
+ * With a single path this reproduces the previous behaviour exactly — the next [limit] occurrences
+ * of the path's delivery day, each flagged against the cut-off. With several paths the lists are
+ * merged and sorted, so the customer of a city served by two tournées simply sees the next dates in
+ * chronological order and picks one; that choice is what assigns them a path.
+ *
+ * Dates are deduplicated: two paths delivering on the same day produce one tile. The order carries
+ * only the date, so there would be nothing to distinguish the two options by, and offering the same
+ * day twice would read as a bug.
+ *
+ * @param paths The paths that serve the customer. Empty yields an empty list.
+ * @param now Injected rather than read from the system clock so the cut-off is testable.
+ * @param limit How many distinct dates to return.
+ */
+class BuildSelectableDeliveryDatesUseCase {
+
+    operator fun invoke(
+        paths: List<DeliveryPath>,
+        now: LocalDateTime,
+        limit: Int = 4
+    ): List<SelectableDeliveryDate> {
+        if (paths.isEmpty() || limit <= 0) return emptyList()
+
+        return paths
+            .flatMap { path -> nextDatesFor(path, now.toLocalDate(), limit) }
+            .sortedBy { it.date }
+            .distinctBy { it.date }
+            .take(limit)
+            .map { it.copy(isPastDeadline = isPastDeadline(it.date, now)) }
+    }
+
+    private fun nextDatesFor(
+        path: DeliveryPath,
+        from: LocalDate,
+        limit: Int
+    ): List<SelectableDeliveryDate> {
+        val targetDay = runCatching { DayOfWeek.valueOf(path.deliveryDay.uppercase()) }
+            .getOrDefault(FALLBACK_DELIVERY_DAY)
+        val weekFields = WeekFields.of(Locale.FRANCE)
+
+        val dates = mutableListOf<SelectableDeliveryDate>()
+        var current = from
+        var scanned = 0
+        while (dates.size < limit && scanned < MAX_DAYS_SCANNED) {
+            if (current.dayOfWeek == targetDay) {
+                val weekNumber = current.get(weekFields.weekOfWeekBasedYear())
+                val isAvailable = when (path.deliveryFrequency) {
+                    "BIWEEKLY_EVEN" -> weekNumber % 2 == 0
+                    "BIWEEKLY_ODD" -> weekNumber % 2 != 0
+                    else -> true // "WEEKLY"
+                }
+                if (isAvailable) {
+                    dates.add(
+                        SelectableDeliveryDate(
+                            date = current,
+                            pathId = path.id,
+                            pathName = path.pathName,
+                            isPastDeadline = false
+                        )
+                    )
+                }
+            }
+            current = current.plusDays(1)
+            scanned++
+        }
+        return dates
+    }
+
+    private fun isPastDeadline(date: LocalDate, now: LocalDateTime): Boolean =
+        now.isAfter(date.minusDays(1).atTime(ORDER_CUTOFF_HOUR, 0))
+}

--- a/delivery/domain/src/main/java/com/mtdevelopment/delivery/domain/usecase/DetermineDeliveryEligibilityUseCase.kt
+++ b/delivery/domain/src/main/java/com/mtdevelopment/delivery/domain/usecase/DetermineDeliveryEligibilityUseCase.kt
@@ -16,7 +16,11 @@ const val MAX_DISTANCE_FOR_PICKUP_METERS = 5000.0
  * Outcome of matching a customer address against the delivery paths.
  */
 enum class DeliveryEligibility {
-    /** A path covers this exact address; [DeliveryEligibilityResult.matchingPath] is set. */
+    /**
+     * At least one path covers this exact address. [DeliveryEligibilityResult.candidatePaths] holds
+     * every path that qualifies — usually one, but several when the shop genuinely serves the
+     * address on more than one tournée and the customer gets to pick a date.
+     */
     DELIVERABLE,
 
     /**
@@ -35,7 +39,12 @@ enum class DeliveryEligibility {
 
 /**
  * @property eligibility What the UI should do next.
- * @property matchingPath Set only when [eligibility] is [DeliveryEligibility.DELIVERABLE].
+ * @property matchingPath The path to use when there is nothing to arbitrate; equal to the first
+ *   entry of [candidatePaths]. Kept as a convenience for callers that only ever need one path.
+ * @property candidatePaths Every path that serves this address, in path order. Empty unless
+ *   [eligibility] is [DeliveryEligibility.DELIVERABLE]. More than one entry means the address is
+ *   legitimately served by several tournées and the customer must be offered the choice — see
+ *   [DetermineDeliveryEligibilityUseCase] for when that happens.
  * @property resolvedCity The customer's city, recovered from the matched path when geocoding
  *   could not supply it.
  * @property resolvedLocation The customer's coordinates, recovered from the matched city's center
@@ -44,6 +53,7 @@ enum class DeliveryEligibility {
 data class DeliveryEligibilityResult(
     val eligibility: DeliveryEligibility,
     val matchingPath: DeliveryPath?,
+    val candidatePaths: List<DeliveryPath>,
     val resolvedCity: String?,
     val resolvedLocation: Pair<Double, Double>?
 )
@@ -55,20 +65,37 @@ data class DeliveryEligibilityResult(
  * typed-address flow and the GPS flow, and was therefore untestable. It is the single decision
  * point now; both flows geocode and then call this.
  *
- * The matching rule that matters, and the one the previous implementation got backwards: a street
- * restriction is scoped to **one city of one path**, so it can only ever disqualify that city. A
- * path listing street restrictions for Boujailles still covers Frasne in full. Previously any path
- * carrying a non-empty street list was excluded outright unless the street matched, which made
- * every other city of that path undeliverable.
+ * A street restriction is scoped to **one city of one path**, so it can only ever disqualify that
+ * city. A path listing street restrictions for Boujailles still covers Frasne in full.
  *
- * Resolution order:
- * 1. A path whose matching city restricts streets **and** whose street list contains the customer's
- *    street. This is the most specific answer, so it wins over an unrestricted match.
- * 2. A path whose matching city carries no street restriction (the whole city is covered).
- * 3. If the city is covered only by street-restricted entries and none matched, the address is a
- *    new street, a hamlet or a typo in a split city: [DeliveryEligibility.STREET_NOT_COVERED].
- * 4. Otherwise fall back to proximity: within [MAX_DISTANCE_FOR_PICKUP_METERS] the customer may
- *    ask for support, beyond it they are not eligible.
+ * ## Resolution
+ *
+ * Each (path, city) pair whose city matches falls into one of three tiers:
+ *
+ * - **street match** — the city restricts streets and one of them is in the address. Scored by the
+ *   length of the matched label, so the most specific wins;
+ * - **whole city** — the city carries no restriction at all;
+ * - **miss** — the city restricts streets and none matched.
+ *
+ * A street match always beats a whole-city match: the shop went to the trouble of naming that
+ * street, so it is the more deliberate answer. Within the winning tier, every path that ties is
+ * returned in [DeliveryEligibilityResult.candidatePaths] and the **customer** picks, by choosing a
+ * delivery date. Nothing here resolves a tie by list order — that order comes from Firestore
+ * document iteration, so silently taking the first would hand the same customer a different
+ * tournée from one session to the next.
+ *
+ * The scoring exists for one concrete case: a split city where one path lists "Rue du Moulin" and
+ * the other "Rue du Moulin Neuf". Street labels are matched loosely inside the address text, so an
+ * address on Moulin Neuf contains both labels. The longer label is the one the customer actually
+ * lives on. The reverse never collides — "Rue du Moulin Neuf" is not contained in "3 rue du
+ * Moulin".
+ *
+ * When no tier matched but at least one city missed on its streets, the address is a new street, a
+ * hamlet or a typo: [DeliveryEligibility.STREET_NOT_COVERED], whether that city sits on one path or
+ * five. A street list is a deliberate statement that the rest of the city is not served, so there
+ * is nothing safe to fall back on. Otherwise proximity decides: within
+ * [MAX_DISTANCE_FOR_PICKUP_METERS] the customer may ask for support, beyond it they are not
+ * eligible.
  *
  * All inputs are already-geocoded values so this stays a pure function, free of Android's
  * `Geocoder`.
@@ -83,6 +110,18 @@ data class DeliveryEligibilityResult(
  */
 class DetermineDeliveryEligibilityUseCase {
 
+    /** One (path, city) pair that matched on the city name. */
+    private data class CityMatch(
+        val path: DeliveryPath,
+        val cityName: String,
+        val cityLocation: Pair<Double, Double>?,
+        val tier: Tier,
+        /** Length of the matched street label; 0 outside [Tier.STREET]. */
+        val score: Int
+    )
+
+    private enum class Tier { STREET, WHOLE_CITY, MISS }
+
     operator fun invoke(
         paths: List<DeliveryPath>,
         userCity: String?,
@@ -90,20 +129,8 @@ class DetermineDeliveryEligibilityUseCase {
         addressText: String?,
         userLocation: Pair<Double, Double>?
     ): DeliveryEligibilityResult {
-        var resolvedCity = userCity
-        var resolvedLocation = userLocation
         var closestDistance = Double.MAX_VALUE
-
-        // Paths whose matching city restricts streets AND whose street list contains the address.
-        val streetMatchedPaths = mutableListOf<DeliveryPath>()
-        // Paths whose matching city has no street restriction at all.
-        val wholeCityPaths = mutableListOf<DeliveryPath>()
-        // Paths that cover the city but only on streets that did not match.
-        val streetMissedPaths = mutableListOf<DeliveryPath>()
-
-        // Recovery values, used when the geocoder gave us neither city nor coordinates.
-        var recoveredCity: String? = null
-        var recoveredLocation: Pair<Double, Double>? = null
+        val matches = mutableListOf<CityMatch>()
 
         for (path in paths) {
             path.cities.forEachIndexed { index, city ->
@@ -121,63 +148,91 @@ class DetermineDeliveryEligibilityUseCase {
                     }
                 }
 
-                if (!matchesCity(city, resolvedCity, addressText)) return@forEachIndexed
+                if (!matchesCity(city, userCity, addressText)) return@forEachIndexed
 
-                if (recoveredCity == null) {
-                    recoveredCity = city.name
-                    recoveredLocation = cityLocation
+                val matchedStreetLength = longestMatchingStreet(city.streets, userStreet, addressText)
+                val tier = when {
+                    city.coversWholeCity -> Tier.WHOLE_CITY
+                    matchedStreetLength > 0 -> Tier.STREET
+                    else -> Tier.MISS
                 }
 
-                when {
-                    city.coversWholeCity -> wholeCityPaths.add(path)
-                    matchesStreet(city.streets, userStreet, addressText) ->
-                        streetMatchedPaths.add(path)
-
-                    else -> streetMissedPaths.add(path)
-                }
+                matches.add(
+                    CityMatch(
+                        path = path,
+                        cityName = city.name,
+                        cityLocation = cityLocation,
+                        tier = tier,
+                        score = if (tier == Tier.STREET) matchedStreetLength else 0
+                    )
+                )
             }
         }
 
-        // Recover what geocoding could not give us from the city we matched on.
-        if (resolvedCity.isNullOrBlank()) {
-            resolvedCity = recoveredCity
-        }
-        if (resolvedLocation == null && recoveredLocation != null) {
-            resolvedLocation = recoveredLocation
+        val candidateMatches = selectCandidates(matches)
+        // A path listing the same city twice must not look like a choice between two tournées.
+        val candidatePaths = candidateMatches.map { it.path }.distinctBy { it.id }
+
+        // Recover what geocoding could not give us, preferably from the path we actually chose.
+        val recoverySource = candidateMatches.firstOrNull() ?: matches.firstOrNull()
+        val resolvedCity = userCity?.takeUnless { it.isBlank() } ?: recoverySource?.cityName
+        val resolvedLocation = userLocation ?: recoverySource?.cityLocation
+        if (userLocation == null && resolvedLocation != null) {
             // An exact city match is as good as being on the path for the proximity check.
             closestDistance = 0.0
         }
 
-        val matchingPath = streetMatchedPaths.firstOrNull() ?: wholeCityPaths.firstOrNull()
-
         val eligibility = when {
-            matchingPath != null -> DeliveryEligibility.DELIVERABLE
-            streetMissedPaths.isNotEmpty() -> DeliveryEligibility.STREET_NOT_COVERED
+            candidatePaths.isNotEmpty() -> DeliveryEligibility.DELIVERABLE
+            matches.any { it.tier == Tier.MISS } -> DeliveryEligibility.STREET_NOT_COVERED
             closestDistance <= MAX_DISTANCE_FOR_PICKUP_METERS -> DeliveryEligibility.ASK_FOR_SUPPORT
             else -> DeliveryEligibility.NOT_ELIGIBLE
         }
 
         return DeliveryEligibilityResult(
             eligibility = eligibility,
-            matchingPath = matchingPath,
+            matchingPath = candidatePaths.firstOrNull(),
+            candidatePaths = candidatePaths,
             resolvedCity = resolvedCity,
             resolvedLocation = resolvedLocation
         )
+    }
+
+    /**
+     * Keeps the most specific tier that produced a match, then everything tied at the top of it.
+     * Returning several is not a failure — it is the shop genuinely covering the address twice.
+     */
+    private fun selectCandidates(matches: List<CityMatch>): List<CityMatch> {
+        val streetMatches = matches.filter { it.tier == Tier.STREET }
+        if (streetMatches.isNotEmpty()) {
+            val bestScore = streetMatches.maxOf { it.score }
+            return streetMatches.filter { it.score == bestScore }
+        }
+        return matches.filter { it.tier == Tier.WHOLE_CITY }
     }
 
     private fun matchesCity(
         city: DeliveryCity,
         userCity: String?,
         addressText: String?
-    ): Boolean = isSameCity(userCity, city.name) || containsNormalized(addressText, city.name, wholeWord = true)
+    ): Boolean = isSameCity(userCity, city.name) ||
+            containsNormalized(addressText, city.name, wholeWord = true)
 
-    private fun matchesStreet(
+    /**
+     * Length of the longest street label of [streets] that matches the address, or 0 when none do.
+     * The length is measured on the normalized label so it stays comparable across accents and
+     * punctuation.
+     */
+    private fun longestMatchingStreet(
         streets: List<String>,
         userStreet: String?,
         addressText: String?
-    ): Boolean = streets.any { street ->
-        isSameCity(userStreet, street) || containsNormalized(addressText, street, wholeWord = false)
-    }
+    ): Int = streets
+        .filter { street ->
+            isSameCity(userStreet, street) || containsNormalized(addressText, street, wholeWord = false)
+        }
+        .maxOfOrNull { it.normalizeCityName().length }
+        ?: 0
 
     /**
      * Accent- and case-insensitive containment. City names are matched on word boundaries so that

--- a/delivery/domain/src/test/java/com/mtdevelopment/delivery/domain/usecase/BuildSelectableDeliveryDatesUseCaseTest.kt
+++ b/delivery/domain/src/test/java/com/mtdevelopment/delivery/domain/usecase/BuildSelectableDeliveryDatesUseCaseTest.kt
@@ -1,0 +1,157 @@
+package com.mtdevelopment.delivery.domain.usecase
+
+import com.mtdevelopment.core.model.DeliveryCity
+import com.mtdevelopment.delivery.domain.model.DeliveryPath
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+/**
+ * The reference instant for every test is Monday 3 August 2026 at 08:00, ISO week 32 (even).
+ * Picking a Monday keeps the arithmetic readable: the next Tuesday is the following day and the
+ * next Friday is four days later, both inside the same week.
+ */
+class BuildSelectableDeliveryDatesUseCaseTest {
+
+    private val useCase = BuildSelectableDeliveryDatesUseCase()
+
+    private val monday3August = LocalDateTime.of(2026, 8, 3, 8, 0)
+
+    private fun path(
+        id: String,
+        name: String = id,
+        day: String,
+        frequency: String = "WEEKLY"
+    ) = DeliveryPath(
+        id = id,
+        pathName = name,
+        cities = listOf(DeliveryCity("Boujailles", 25560)),
+        locations = listOf(46.85 to 6.15),
+        deliveryDay = day,
+        deliveryFrequency = frequency,
+        geoJson = null
+    )
+
+    @Test
+    fun `weekly path yields the next four occurrences of its day`() {
+        val result = useCase(listOf(path("a", day = "TUESDAY")), monday3August)
+
+        assertEquals(
+            listOf(
+                LocalDate.of(2026, 8, 4),
+                LocalDate.of(2026, 8, 11),
+                LocalDate.of(2026, 8, 18),
+                LocalDate.of(2026, 8, 25)
+            ),
+            result.map { it.date }
+        )
+        assertTrue(result.all { it.pathId == "a" })
+    }
+
+    @Test
+    fun `biweekly even path only yields even weeks`() {
+        val result = useCase(listOf(path("a", day = "TUESDAY", frequency = "BIWEEKLY_EVEN")), monday3August)
+
+        // Weeks 32, 34, 36, 38 — every other Tuesday starting with the current, even, week.
+        assertEquals(
+            listOf(
+                LocalDate.of(2026, 8, 4),
+                LocalDate.of(2026, 8, 18),
+                LocalDate.of(2026, 9, 1),
+                LocalDate.of(2026, 9, 15)
+            ),
+            result.map { it.date }
+        )
+    }
+
+    @Test
+    fun `biweekly odd path skips the current even week`() {
+        val result = useCase(listOf(path("a", day = "TUESDAY", frequency = "BIWEEKLY_ODD")), monday3August)
+
+        assertEquals(LocalDate.of(2026, 8, 11), result.first().date)
+        assertEquals(4, result.size)
+    }
+
+    @Test
+    fun `two paths are merged in chronological order and each date keeps its own path`() {
+        val result = useCase(
+            listOf(
+                path("a", name = "Parcours A", day = "FRIDAY"),
+                path("b", name = "Parcours B", day = "TUESDAY")
+            ),
+            monday3August
+        )
+
+        assertEquals(
+            listOf(
+                LocalDate.of(2026, 8, 4) to "b",  // Tuesday
+                LocalDate.of(2026, 8, 7) to "a",  // Friday
+                LocalDate.of(2026, 8, 11) to "b",
+                LocalDate.of(2026, 8, 14) to "a"
+            ),
+            result.map { it.date to it.pathId }
+        )
+    }
+
+    /**
+     * Two tournées on the same day are indistinguishable to the customer — the order records only
+     * the date — so offering the day twice would look like a bug.
+     */
+    @Test
+    fun `paths sharing a delivery day produce a single tile per date`() {
+        val result = useCase(
+            listOf(path("a", day = "TUESDAY"), path("b", day = "TUESDAY")),
+            monday3August
+        )
+
+        assertEquals(4, result.size)
+        assertEquals(result.map { it.date }.distinct(), result.map { it.date })
+        assertTrue(result.all { it.pathId == "a" })
+    }
+
+    @Test
+    fun `a date is past its deadline once the day before at noon has passed`() {
+        // Monday 12:01 — the Tuesday cut-off (Monday noon) has just closed.
+        val justAfterCutoff = LocalDateTime.of(2026, 8, 3, 12, 1)
+
+        val result = useCase(listOf(path("a", day = "TUESDAY")), justAfterCutoff)
+
+        assertTrue(result.first().isPastDeadline)
+        assertFalse(result[1].isPastDeadline)
+    }
+
+    @Test
+    fun `a date is still open right on the deadline`() {
+        val onCutoff = LocalDateTime.of(2026, 8, 3, 12, 0)
+
+        val result = useCase(listOf(path("a", day = "TUESDAY")), onCutoff)
+
+        assertFalse(result.first().isPastDeadline)
+    }
+
+    @Test
+    fun `an unparseable delivery day falls back to friday instead of crashing`() {
+        val result = useCase(listOf(path("a", day = "Mardi")), monday3August)
+
+        assertEquals(LocalDate.of(2026, 8, 7), result.first().date)
+    }
+
+    @Test
+    fun `no paths yields no dates`() {
+        assertEquals(emptyList<SelectableDeliveryDate>(), useCase(emptyList(), monday3August))
+    }
+
+    @Test
+    fun `the limit caps the merged list rather than each path`() {
+        val result = useCase(
+            listOf(path("a", day = "FRIDAY"), path("b", day = "TUESDAY")),
+            monday3August,
+            limit = 3
+        )
+
+        assertEquals(3, result.size)
+    }
+}

--- a/delivery/domain/src/test/java/com/mtdevelopment/delivery/domain/usecase/DetermineDeliveryEligibilityUseCaseTest.kt
+++ b/delivery/domain/src/test/java/com/mtdevelopment/delivery/domain/usecase/DetermineDeliveryEligibilityUseCaseTest.kt
@@ -297,4 +297,200 @@ class DetermineDeliveryEligibilityUseCaseTest {
         assertEquals(DeliveryEligibility.NOT_ELIGIBLE, result.eligibility)
         assertNull(result.matchingPath)
     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // One test per row of the resolution table.
+    // A path whose entry for Boujailles carries no street list covers the whole commune.
+    ///////////////////////////////////////////////////////////////////////////
+
+    private fun wholeCityPath(id: String, day: String = "MONDAY") = DeliveryPath(
+        id = id,
+        pathName = "Parcours $id",
+        cities = listOf(DeliveryCity("Boujailles", 25560)),
+        locations = listOf(46.85 to 6.15),
+        deliveryDay = day,
+        geoJson = null
+    )
+
+    @Test
+    fun `every path restricting the city and no street match offers nothing to choose from`() {
+        val result = useCase(
+            paths = allPaths,
+            userCity = "Boujailles",
+            userStreet = "Impasse des Lilas",
+            addressText = "2 Impasse des Lilas, 25560 Boujailles",
+            userLocation = 46.85 to 6.15
+        )
+
+        assertEquals(DeliveryEligibility.STREET_NOT_COVERED, result.eligibility)
+        assertEquals(emptyList<DeliveryPath>(), result.candidatePaths)
+    }
+
+    /**
+     * A street list is a deliberate statement that the rest of the commune is not served, so a
+     * single restricting path is no more of a licence to guess than two are.
+     */
+    @Test
+    fun `a lone path restricting the city still routes to the shop`() {
+        val result = useCase(
+            paths = listOf(pathA),
+            userCity = "Boujailles",
+            userStreet = "Impasse des Lilas",
+            addressText = "2 Impasse des Lilas, 25560 Boujailles",
+            userLocation = 46.85 to 6.15
+        )
+
+        assertEquals(DeliveryEligibility.STREET_NOT_COVERED, result.eligibility)
+        assertEquals(emptyList<DeliveryPath>(), result.candidatePaths)
+    }
+
+    @Test
+    fun `an unmatched street restriction hands the city to the path that covers it whole`() {
+        val result = useCase(
+            paths = listOf(pathA, wholeCityPath("open")),
+            userCity = "Boujailles",
+            userStreet = "Impasse des Lilas",
+            addressText = "2 Impasse des Lilas, 25560 Boujailles",
+            userLocation = 46.85 to 6.15
+        )
+
+        assertEquals(DeliveryEligibility.DELIVERABLE, result.eligibility)
+        assertEquals(listOf("open"), result.candidatePaths.map { it.id })
+    }
+
+    @Test
+    fun `a matched street beats the path covering the city whole`() {
+        val result = useCase(
+            paths = listOf(pathA, wholeCityPath("open")),
+            userCity = "Boujailles",
+            userStreet = "Rue du Moulin",
+            addressText = "12 Rue du Moulin, 25560 Boujailles",
+            userLocation = 46.85 to 6.15
+        )
+
+        assertEquals(listOf("path-a"), result.candidatePaths.map { it.id })
+    }
+
+    @Test
+    fun `a city covered whole by two paths lets the customer choose`() {
+        val result = useCase(
+            paths = listOf(wholeCityPath("open-1"), wholeCityPath("open-2", day = "THURSDAY")),
+            userCity = "Boujailles",
+            userStreet = "Impasse des Lilas",
+            addressText = "2 Impasse des Lilas, 25560 Boujailles",
+            userLocation = 46.85 to 6.15
+        )
+
+        assertEquals(DeliveryEligibility.DELIVERABLE, result.eligibility)
+        assertEquals(listOf("open-1", "open-2"), result.candidatePaths.map { it.id })
+        assertEquals("open-1", result.matchingPath?.id)
+    }
+
+    @Test
+    fun `a restricted path that missed does not join the choice between two open paths`() {
+        val result = useCase(
+            paths = listOf(pathA, wholeCityPath("open-1"), wholeCityPath("open-2")),
+            userCity = "Boujailles",
+            userStreet = "Impasse des Lilas",
+            addressText = "2 Impasse des Lilas, 25560 Boujailles",
+            userLocation = 46.85 to 6.15
+        )
+
+        assertEquals(listOf("open-1", "open-2"), result.candidatePaths.map { it.id })
+    }
+
+    @Test
+    fun `the same street listed on two paths lets the customer choose`() {
+        val twin = pathB.copy(
+            id = "path-b2",
+            cities = listOf(DeliveryCity("Boujailles", 25560, listOf("Rue de la Gare")))
+        )
+
+        val result = useCase(
+            paths = listOf(pathB, twin),
+            userCity = "Boujailles",
+            userStreet = "Rue de la Gare",
+            addressText = "1 Rue de la Gare, 25560 Boujailles",
+            userLocation = 46.85 to 6.15
+        )
+
+        assertEquals(DeliveryEligibility.DELIVERABLE, result.eligibility)
+        assertEquals(listOf("path-b", "path-b2"), result.candidatePaths.map { it.id })
+    }
+
+    /**
+     * Street labels are matched loosely inside the address text, so an address on "Rue du Moulin
+     * Neuf" also contains "Rue du Moulin". The longer label is the street the customer lives on.
+     */
+    @Test
+    fun `the longer street label wins when one label is a prefix of the other`() {
+        val neuf = pathB.copy(
+            id = "path-neuf",
+            cities = listOf(DeliveryCity("Boujailles", 25560, listOf("Rue du Moulin Neuf")))
+        )
+
+        val result = useCase(
+            paths = listOf(pathA, neuf),
+            userCity = "Boujailles",
+            userStreet = null,
+            addressText = "8 Rue du Moulin Neuf, 25560 Boujailles",
+            userLocation = 46.85 to 6.15
+        )
+
+        assertEquals(listOf("path-neuf"), result.candidatePaths.map { it.id })
+    }
+
+    /** The reverse never collides: the longer label is simply absent from the shorter address. */
+    @Test
+    fun `the shorter street label still wins on its own address`() {
+        val neuf = pathB.copy(
+            id = "path-neuf",
+            cities = listOf(DeliveryCity("Boujailles", 25560, listOf("Rue du Moulin Neuf")))
+        )
+
+        val result = useCase(
+            paths = listOf(pathA, neuf),
+            userCity = "Boujailles",
+            userStreet = null,
+            addressText = "3 Rue du Moulin, 25560 Boujailles",
+            userLocation = 46.85 to 6.15
+        )
+
+        assertEquals(listOf("path-a"), result.candidatePaths.map { it.id })
+    }
+
+    @Test
+    fun `a city listed twice on one path is not a choice between two tournees`() {
+        val duplicated = wholeCityPath("open").copy(
+            cities = listOf(
+                DeliveryCity("Boujailles", 25560),
+                DeliveryCity("Boujailles", 25560)
+            ),
+            locations = listOf(46.85 to 6.15, 46.85 to 6.15)
+        )
+
+        val result = useCase(
+            paths = listOf(duplicated),
+            userCity = "Boujailles",
+            userStreet = null,
+            addressText = "2 Impasse des Lilas, 25560 Boujailles",
+            userLocation = 46.85 to 6.15
+        )
+
+        assertEquals(listOf("open"), result.candidatePaths.map { it.id })
+    }
+
+    @Test
+    fun `an unambiguous match exposes exactly one candidate`() {
+        val result = useCase(
+            paths = allPaths,
+            userCity = "Frasne",
+            userStreet = null,
+            addressText = "5 Rue de la Gare, 25560 Frasne",
+            userLocation = 46.85 to 6.17
+        )
+
+        assertEquals(listOf("path-a"), result.candidatePaths.map { it.id })
+        assertEquals(result.matchingPath, result.candidatePaths.single())
+    }
 }

--- a/delivery/presentation/src/admin/java/com/mtdevelopment/delivery/presentation/screen/DeliveryOptionScreen.kt
+++ b/delivery/presentation/src/admin/java/com/mtdevelopment/delivery/presentation/screen/DeliveryOptionScreen.kt
@@ -144,15 +144,16 @@ fun DeliveryOptionScreen(
 
         if (state.value.datePickerVisibility) {
             DatePickerComposable(
-                selectedPath = state.value.selectedPath,
+                paths = listOfNotNull(state.value.selectedPath),
                 shouldRemoveDatePicker = {
                     deliveryViewModel.setIsDatePickerShown(false)
                 },
                 newDateFieldText = {
                     deliveryViewModel.setDateFieldText(it)
                 },
-                onDateSelected = {
-                    deliveryViewModel.saveSelectedDate(it)
+                onDateSelected = { date, path ->
+                    deliveryViewModel.updateSelectedPath(path)
+                    deliveryViewModel.saveSelectedDate(date)
                 }
             )
         }

--- a/delivery/presentation/src/client/java/com/mtdevelopment/delivery/presentation/screen/DeliveryOptionScreen.kt
+++ b/delivery/presentation/src/client/java/com/mtdevelopment/delivery/presentation/screen/DeliveryOptionScreen.kt
@@ -143,7 +143,7 @@ fun DeliveryOptionScreen(
         if (state.value.shouldShowLocalisationPermission) {
             PermissionManagerComposable(
                 allPaths = state.value.deliveryPaths,
-                onUpdateEligibility = { eligibility, city, userAddress, path ->
+                onUpdateEligibility = { eligibility, city, userAddress, candidatePaths ->
                     // Logic to handle location-based delivery matching
                     if (city != null) {
                         deliveryViewModel.updateUserCity(city)
@@ -151,7 +151,7 @@ fun DeliveryOptionScreen(
                     if (userAddress != null) {
                         deliveryViewModel.setAddressFieldText(userAddress)
                     }
-                    deliveryViewModel.updateSelectedPath(path)
+                    deliveryViewModel.updateCandidatePaths(candidatePaths)
                     deliveryViewModel.updateEligibility(eligibility)
                 },
                 onUpdateUserLocation = {
@@ -192,15 +192,21 @@ fun DeliveryOptionScreen(
         // Confirming a date persists it and moves on to the pre-payment validation screen.
         if (state.value.datePickerVisibility) {
             DatePickerComposable(
-                selectedPath = state.value.selectedPath,
+                // Every path serving the address, not just one: when a commune is on two tournées
+                // the merged list is what lets the customer pick, and their pick assigns the path.
+                paths = state.value.candidatePaths,
                 shouldRemoveDatePicker = {
                     deliveryViewModel.setIsDatePickerShown(false)
                 },
                 newDateFieldText = {
                     deliveryViewModel.setDateFieldText(it)
                 },
-                onDateSelected = {
-                    deliveryViewModel.saveSelectedDate(it)
+                onDateSelected = { date, path ->
+                    deliveryViewModel.updateSelectedPath(path)
+                    // Re-persist now that the tournée is settled, so `lastSelectedPath` records
+                    // what the customer actually chose.
+                    deliveryViewModel.saveUserInfo()
+                    deliveryViewModel.saveSelectedDate(date)
                     navigateToCheckout.invoke()
                 }
             )

--- a/delivery/presentation/src/main/java/com/mtdevelopment/delivery/presentation/composable/CustomerContent.kt
+++ b/delivery/presentation/src/main/java/com/mtdevelopment/delivery/presentation/composable/CustomerContent.kt
@@ -88,14 +88,14 @@ fun CustomerContent(
                 address = state.value.deliveryAddressSearchQuery,
                 location = null,
                 allPaths = state.value.deliveryPaths,
-                onResult = { eligibility, city, userLocation, selectedPath ->
+                onResult = { eligibility, city, userLocation, candidatePaths ->
                     if (city != null) {
                         deliveryViewModel.updateUserCity(city)
                     }
                     if (userLocation != null) {
                         deliveryViewModel.updateUserCityLocation(userLocation)
                     }
-                    deliveryViewModel.updateSelectedPath(selectedPath)
+                    deliveryViewModel.updateCandidatePaths(candidatePaths)
                     deliveryViewModel.updateEligibility(eligibility)
                 }
             )
@@ -209,16 +209,19 @@ fun CustomerContent(
                             address = string,
                             location = suggestion,
                             allPaths = state.value.deliveryPaths,
-                            onResult = { eligibility, city, userLocation, selectedPath ->
+                            // Same path as the GPS flow. Setting the legacy booleans by hand here
+                            // used to leave `streetNotCovered` stale, so a customer on an uncovered
+                            // street of a split city got no button at all — neither "Continuer"
+                            // nor the request-support one.
+                            onResult = { eligibility, city, userLocation, candidatePaths ->
                                 if (city != null) {
                                     deliveryViewModel.updateUserCity(city)
                                 }
                                 if (userLocation != null) {
                                     deliveryViewModel.updateUserCityLocation(userLocation)
                                 }
-                                deliveryViewModel.updateSelectedPath(selectedPath)
-                                deliveryViewModel.updateUserLocationOnPath(eligibility == DeliveryEligibility.DELIVERABLE)
-                                deliveryViewModel.updateUserLocationCloseFromPath(eligibility == DeliveryEligibility.ASK_FOR_SUPPORT)
+                                deliveryViewModel.updateCandidatePaths(candidatePaths)
+                                deliveryViewModel.updateEligibility(eligibility)
                             }
                         )
                     }
@@ -259,12 +262,13 @@ fun CustomerContent(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            if (state.value.localisationSuccess || state.value.selectedPath != null || state.value.userLocationOnPath || state.value.deliveryAddressSearchQuery != "") {
+            if (state.value.localisationSuccess || state.value.selectedPath != null || state.value.candidatePaths.isNotEmpty() || state.value.userLocationOnPath || state.value.deliveryAddressSearchQuery != "") {
                 LocalisationTextComposable(
                     selectedPath = state.value.selectedPath,
                     geolocIsOnPath = state.value.userLocationOnPath && state.value.localisationSuccess,
                     canAskForDelivery = state.value.userLocationCloseFromPath,
                     streetNotCovered = state.value.streetNotCovered,
+                    multiplePathsAvailable = state.value.candidatePaths.size > 1,
                     userCity = state.value.userCity
                 )
             } else {
@@ -286,13 +290,15 @@ fun CustomerContent(
     }
 
     when {
-        state.value.userLocationCloseFromPath -> {
+        // `streetNotCovered` gets its own condition rather than riding on the near-miss flag: it is
+        // the one verdict where the city IS served, so it must not depend on a proximity check.
+        state.value.streetNotCovered || state.value.userLocationCloseFromPath -> {
             PrimaryButton(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 16.dp),
                 text = if (state.value.streetNotCovered) {
-                    "Demander mon jour de livraison"
+                    "Demander l'ajout de ma rue"
                 } else {
                     "Demander une prise en charge"
                 },
@@ -310,7 +316,7 @@ fun CustomerContent(
                             putExtra(
                                 Intent.EXTRA_SUBJECT,
                                 if (state.value.streetNotCovered) {
-                                    "Demande de jour de livraison"
+                                    "Demande d'ajout de ma rue"
                                 } else {
                                     "Demande d'ajout aux livraisons"
                                 }
@@ -320,8 +326,9 @@ fun CustomerContent(
                                 if (state.value.streetNotCovered) {
                                     "Bonjour Mr. Marchal.\n\nJ'habite à ${state.value.userCity}, " +
                                             "à l'adresse suivante :\n${state.value.deliveryAddressSearchQuery}" +
-                                            "\n\nL'application n'a pas réussi à déterminer ma tournée. " +
-                                            "Pourriez-vous me dire quel jour vous passez dans ma rue ?" +
+                                            "\n\nMa rue n'apparaît pas dans l'application. " +
+                                            "Pourriez-vous l'ajouter à la tournée qui la dessert, " +
+                                            "et me dire quel jour vous y passez ?" +
                                             "\n\nMerci d'avance !"
                                 } else {
                                     "Bonjour Mr. Marchal.\n\nJ'habite à une " +
@@ -342,7 +349,9 @@ fun CustomerContent(
         }
 
 
-        state.value.selectedPath != null -> {
+        // Not `selectedPath != null`: when several tournées serve the address none is selected yet,
+        // and it is the date picker that settles it.
+        state.value.candidatePaths.isNotEmpty() -> {
             // Step 1 → Step 2: "Continuer" opens the delivery-date calendar.
             // Persisting the date and navigating to the payment screen happens once
             // the customer confirms a date (handled by the screen's date dialog).
@@ -374,7 +383,7 @@ private suspend fun checkLocationEligibility(
     address: String? = null,
     location: AutoCompleteSuggestion? = null,
     allPaths: List<UiDeliveryPath>,
-    onResult: (eligibility: DeliveryEligibility, city: String?, userLocation: Pair<Double, Double>?, selectedPath: UiDeliveryPath?) -> Unit
+    onResult: (eligibility: DeliveryEligibility, city: String?, userLocation: Pair<Double, Double>?, candidatePaths: List<UiDeliveryPath>) -> Unit
 ) {
     withContext(Dispatchers.IO) {
         val geocoder = Geocoder(context)
@@ -443,7 +452,7 @@ private suspend fun checkLocationEligibility(
                 result.eligibility,
                 result.resolvedCity,
                 result.resolvedLocation,
-                result.matchingPath?.let { matched -> allPaths.find { it.id == matched.id } }
+                result.candidatePaths.mapNotNull { matched -> allPaths.find { it.id == matched.id } }
             )
         }
     }

--- a/delivery/presentation/src/main/java/com/mtdevelopment/delivery/presentation/composable/DatePickerComposable.kt
+++ b/delivery/presentation/src/main/java/com/mtdevelopment/delivery/presentation/composable/DatePickerComposable.kt
@@ -39,7 +39,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import java.time.DayOfWeek
+import com.mtdevelopment.delivery.domain.usecase.BuildSelectableDeliveryDatesUseCase
+import com.mtdevelopment.delivery.presentation.model.toDomainDeliveryPath
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -48,46 +49,36 @@ import java.time.format.TextStyle
 import java.time.temporal.ChronoUnit
 import java.util.Locale
 
+/**
+ * Delivery-date calendar.
+ *
+ * Takes every path that serves the customer rather than a single one: a commune covered by two
+ * tournées produces one merged, chronological list, and the date the customer picks is what assigns
+ * them a path. The tournée name is shown on the tiles only when there is actually something to
+ * choose between — labelling a single-path list would just be noise.
+ *
+ * @param paths Paths serving the address. One entry reproduces the previous behaviour exactly.
+ * @param onDateSelected Receives the chosen date and the path it belongs to; the caller must apply
+ *   that path before persisting the order.
+ */
 @Composable
 fun DatePickerComposable(
-    selectedPath: com.mtdevelopment.delivery.presentation.model.UiDeliveryPath?,
+    paths: List<com.mtdevelopment.delivery.presentation.model.UiDeliveryPath>,
     shouldRemoveDatePicker: () -> Unit,
     newDateFieldText: (String) -> Unit,
-    onDateSelected: (Long) -> Unit = {}
+    onDateSelected: (Long, com.mtdevelopment.delivery.presentation.model.UiDeliveryPath) -> Unit = { _, _ -> }
 ) {
-    // Generate the next 4 available delivery dates
-    val availableDates = remember(selectedPath) {
-        if (selectedPath != null) {
-            val targetDay = try {
-                DayOfWeek.valueOf(selectedPath.deliveryDay.uppercase())
-            } catch (e: Exception) {
-                DayOfWeek.FRIDAY
-            }
-            val dates = mutableListOf<LocalDate>()
-            var current = LocalDate.now()
-            val weekFields = java.time.temporal.WeekFields.of(java.util.Locale.FRANCE)
-            while (dates.size < 4) {
-                if (current.dayOfWeek == targetDay) {
-                    val weekNumber = current.get(weekFields.weekOfWeekBasedYear())
-                    val isAvailable = when (selectedPath.deliveryFrequency) {
-                        "BIWEEKLY_EVEN" -> weekNumber % 2 == 0
-                        "BIWEEKLY_ODD" -> weekNumber % 2 != 0
-                        else -> true // "WEEKLY"
-                    }
-                    if (isAvailable) {
-                        dates.add(current)
-                    }
-                }
-                current = current.plusDays(1)
-            }
-            dates
-        } else {
-            emptyList()
-        }
+    val now = remember { LocalDateTime.now(ZoneId.systemDefault()) }
+
+    val availableDates = remember(paths, now) {
+        BuildSelectableDeliveryDatesUseCase().invoke(
+            paths = paths.map { it.toDomainDeliveryPath() },
+            now = now
+        )
     }
+    val showPathLabels = paths.size > 1
 
     var selectedDate by remember { mutableStateOf<LocalDate?>(null) }
-    val now = remember { LocalDateTime.now(ZoneId.systemDefault()) }
 
     Dialog(
         onDismissRequest = { shouldRemoveDatePicker() },
@@ -144,10 +135,9 @@ fun DatePickerComposable(
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     } else {
-                        availableDates.forEachIndexed { index, date ->
-                            // Rule: orders allowed up to the day before at 12:00 PM
-                            val limitDateTime = date.minusDays(1).atTime(12, 0)
-                            val isPastDeadline = now.isAfter(limitDateTime)
+                        availableDates.forEachIndexed { index, option ->
+                            val date = option.date
+                            val isPastDeadline = option.isPastDeadline
 
                             val isSelected = selectedDate == date
                             val dayName =
@@ -255,8 +245,33 @@ fun DatePickerComposable(
                                         }
                                     )
                                 }
+                                // Only meaningful when several tournées are on offer — otherwise
+                                // every tile would carry the same name.
+                                if (showPathLabels) {
+                                    Text(
+                                        modifier = Modifier
+                                            .padding(start = 8.dp)
+                                            .clip(RoundedCornerShape(50))
+                                            .background(
+                                                if (isPastDeadline) {
+                                                    MaterialTheme.colorScheme.surfaceContainerHighest
+                                                } else {
+                                                    MaterialTheme.colorScheme.secondaryContainer
+                                                }
+                                            )
+                                            .padding(horizontal = 10.dp, vertical = 4.dp),
+                                        text = option.pathName,
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = if (isPastDeadline) {
+                                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+                                        } else {
+                                            MaterialTheme.colorScheme.onSecondaryContainer
+                                        }
+                                    )
+                                }
                                 if (isSelected && !isPastDeadline) {
                                     Icon(
+                                        modifier = Modifier.padding(start = 8.dp),
                                         imageVector = Icons.Default.CheckCircle,
                                         contentDescription = "Selected",
                                         tint = MaterialTheme.colorScheme.primary
@@ -294,14 +309,20 @@ fun DatePickerComposable(
                     Spacer(modifier = Modifier.width(12.dp))
                     Button(
                         onClick = {
-                            selectedDate?.let { date ->
+                            val chosen = selectedDate?.let { date ->
+                                availableDates.firstOrNull { it.date == date }
+                            }
+                            val chosenPath = chosen?.let { option ->
+                                paths.firstOrNull { it.id == option.pathId }
+                            }
+                            if (chosen != null && chosenPath != null) {
                                 val formattedDate =
-                                    DateTimeFormatter.ofPattern("dd/MM/yyyy").format(date)
+                                    DateTimeFormatter.ofPattern("dd/MM/yyyy").format(chosen.date)
                                 newDateFieldText(formattedDate)
                                 val epochMillis =
-                                    date.atStartOfDay(ZoneId.systemDefault()).toInstant()
+                                    chosen.date.atStartOfDay(ZoneId.systemDefault()).toInstant()
                                         .toEpochMilli()
-                                onDateSelected(epochMillis)
+                                onDateSelected(epochMillis, chosenPath)
                             }
                             shouldRemoveDatePicker()
                         },

--- a/delivery/presentation/src/main/java/com/mtdevelopment/delivery/presentation/composable/LocalisationTextComposable.kt
+++ b/delivery/presentation/src/main/java/com/mtdevelopment/delivery/presentation/composable/LocalisationTextComposable.kt
@@ -22,15 +22,22 @@ import com.mtdevelopment.delivery.presentation.model.getFormattedDeliveryDayAndF
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 
+/**
+ * @param multiplePathsAvailable The address is served by several tournées and none has been settled
+ *   on yet. Without this the composable would fall through to the "not on a path" cycling text and
+ *   tell a perfectly deliverable customer we don't come to them.
+ */
 @Composable
 fun LocalisationTextComposable(
     selectedPath: UiDeliveryPath?,
     geolocIsOnPath: Boolean,
     canAskForDelivery: Boolean,
     streetNotCovered: Boolean = false,
+    multiplePathsAvailable: Boolean = false,
     userCity: String
 ) {
-    val isCyclingTextMode = selectedPath == null && !canAskForDelivery
+    val isCyclingTextMode =
+        selectedPath == null && !canAskForDelivery && !streetNotCovered && !multiplePathsAvailable
 
     val cyclingTextResourceIds = remember {
         listOf(
@@ -98,6 +105,12 @@ fun LocalisationTextComposable(
         // which one. Say so explicitly rather than let the near-miss wording imply we don't deliver.
         streetNotCovered -> {
             stringResource(R.string.auto_geoloc_street_not_covered, userCity)
+        }
+
+        // Several tournées serve this commune and nothing in the address picks between them, so
+        // the customer decides — by choosing the date that suits them.
+        multiplePathsAvailable && selectedPath == null -> {
+            stringResource(R.string.auto_geoloc_multiple_paths, userCity)
         }
 
         geolocIsOnPath && selectedPath != null -> {

--- a/delivery/presentation/src/main/java/com/mtdevelopment/delivery/presentation/composable/PermissionManagerComposable.kt
+++ b/delivery/presentation/src/main/java/com/mtdevelopment/delivery/presentation/composable/PermissionManagerComposable.kt
@@ -37,7 +37,7 @@ import kotlin.coroutines.suspendCoroutine
 @Composable
 fun PermissionManagerComposable(
     allPaths: List<UiDeliveryPath>,
-    onUpdateEligibility: (eligibility: DeliveryEligibility, city: String?, userAddress: String?, selectedPath: UiDeliveryPath?) -> Unit,
+    onUpdateEligibility: (eligibility: DeliveryEligibility, city: String?, userAddress: String?, candidatePaths: List<UiDeliveryPath>) -> Unit,
     onUpdateUserLocation: (Pair<Double, Double>?) -> Unit,
     setIsLoading: (Boolean) -> Unit,
     onUpdateLocalisationState: (Boolean) -> Unit,
@@ -68,8 +68,8 @@ fun PermissionManagerComposable(
                             context = context,
                             userLocation = userLocation,
                             allPaths = allPaths,
-                            onResult = { eligibility, city, userAddress, path ->
-                                onUpdateEligibility(eligibility, city, userAddress, path)
+                            onResult = { eligibility, city, userAddress, candidatePaths ->
+                                onUpdateEligibility(eligibility, city, userAddress, candidatePaths)
                                 setIsLoading(false)
                             }
                         )
@@ -77,7 +77,7 @@ fun PermissionManagerComposable(
                 },
                 onFailure = {
                     onUpdateUserLocation(null)
-                    onUpdateEligibility(DeliveryEligibility.NOT_ELIGIBLE, "Unknown", null, null)
+                    onUpdateEligibility(DeliveryEligibility.NOT_ELIGIBLE, "Unknown", null, emptyList())
                     onUpdateLocalisationState.invoke(false)
                     setIsLoading(false)
                 }
@@ -124,7 +124,7 @@ private suspend fun checkLocationEligibility(
     context: Context,
     userLocation: Pair<Double, Double>,
     allPaths: List<UiDeliveryPath>,
-    onResult: (eligibility: DeliveryEligibility, city: String?, userAddress: String?, selectedPath: UiDeliveryPath?) -> Unit
+    onResult: (eligibility: DeliveryEligibility, city: String?, userAddress: String?, candidatePaths: List<UiDeliveryPath>) -> Unit
 ) {
     withContext(Dispatchers.IO) {
         val geocoder = Geocoder(context)
@@ -172,7 +172,7 @@ private suspend fun checkLocationEligibility(
                 result.eligibility,
                 result.resolvedCity,
                 userAddress,
-                result.matchingPath?.let { matched -> allPaths.find { it.id == matched.id } }
+                result.candidatePaths.mapNotNull { matched -> allPaths.find { it.id == matched.id } }
             )
         }
     }

--- a/delivery/presentation/src/main/java/com/mtdevelopment/delivery/presentation/state/DeliveryUiDataState.kt
+++ b/delivery/presentation/src/main/java/com/mtdevelopment/delivery/presentation/state/DeliveryUiDataState.kt
@@ -30,6 +30,10 @@ import com.mtdevelopment.delivery.presentation.model.UiDeliveryPath
  * @property userCity The name of the city extracted from the user's location or selection.
  * @property userCityLocation The (Lat, Lng) coordinates of the user's city.
  * @property selectedPath The delivery path chosen by the user or matched by the system.
+ * @property candidatePaths Every path that serves the customer's address. Holds one entry in the
+ *   ordinary case and several when the address is genuinely covered by more than one tournée — the
+ *   date picker then merges their dates and the customer's pick decides the path. Empty until an
+ *   address has been matched.
  * @property deliveryPaths List of all available delivery paths.
  * @property isBillingDifferent Flag indicating if the user wants to provide a different billing address.
  */
@@ -61,6 +65,7 @@ data class DeliveryUiDataState(
     val userCity: String = "",
     val userCityLocation: Pair<Double, Double>? = null,
     val selectedPath: UiDeliveryPath? = null,
+    val candidatePaths: List<UiDeliveryPath> = emptyList(),
 
     val deliveryPaths: List<UiDeliveryPath> = emptyList(),
     val isBillingDifferent: Boolean = false

--- a/delivery/presentation/src/main/java/com/mtdevelopment/delivery/presentation/viewmodel/DeliveryViewModel.kt
+++ b/delivery/presentation/src/main/java/com/mtdevelopment/delivery/presentation/viewmodel/DeliveryViewModel.kt
@@ -193,10 +193,13 @@ class DeliveryViewModel(
      */
     fun saveUserInfo(onError: () -> Unit = {}) {
         viewModelScope.launch {
-            // Validation: Ensure mandatory fields are filled
-            if (deliveryUiDataState.selectedPath == null || 
-                deliveryUiDataState.deliveryAddressSearchQuery.isBlank() ||
-                deliveryUiDataState.userNameFieldText.isBlank()
+            // Validation: Ensure mandatory fields are filled.
+            // A null selectedPath is not a failure when several tournées are still in the running:
+            // the customer settles it by picking a date, and this runs again with the winner.
+            if (deliveryUiDataState.deliveryAddressSearchQuery.isBlank() ||
+                deliveryUiDataState.userNameFieldText.isBlank() ||
+                (deliveryUiDataState.selectedPath == null &&
+                        deliveryUiDataState.candidatePaths.isEmpty())
             ) {
                 onError.invoke()
                 return@launch
@@ -208,7 +211,8 @@ class DeliveryViewModel(
                     email = existingUserInfo?.email ?: "",
                     address = deliveryUiDataState.deliveryAddressSearchQuery,
                     billingAddress = deliveryUiDataState.billingAddressSearchQuery,
-                    lastSelectedPath = deliveryUiDataState.selectedPath?.name ?: ""
+                    lastSelectedPath = deliveryUiDataState.selectedPath?.name
+                        ?: existingUserInfo?.lastSelectedPath ?: ""
                 )
             )
         }
@@ -424,6 +428,26 @@ class DeliveryViewModel(
 
     fun updateSelectedPath(path: UiDeliveryPath?) {
         deliveryUiDataState = deliveryUiDataState.copy(selectedPath = path)
+    }
+
+    /**
+     * Records every path that serves the customer's address, and settles on one when it can.
+     *
+     * A single candidate is selected outright. Several means the shop genuinely covers the address
+     * on more than one tournée: we keep the customer's previous pick if it is still on the list —
+     * so re-entering the screen does not silently move them — and otherwise leave [selectedPath]
+     * null so the merged date picker is what assigns the path.
+     */
+    fun updateCandidatePaths(paths: List<UiDeliveryPath>) {
+        val previousId = deliveryUiDataState.selectedPath?.id
+        deliveryUiDataState = deliveryUiDataState.copy(
+            candidatePaths = paths,
+            selectedPath = when {
+                paths.isEmpty() -> null
+                paths.size == 1 -> paths.single()
+                else -> paths.firstOrNull { it.id == previousId }
+            }
+        )
     }
 
     fun setIsBillingDifferent(isDifferent: Boolean) {

--- a/delivery/presentation/src/main/res/values/strings.xml
+++ b/delivery/presentation/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="auto_geoloc_not_on_path_at_all_part_3">En attendant, n\'hésitez pas à vous faire livrer chez des proches qui habiteraient sur un parcours !</string>
     <string name="auto_geoloc_not_on_path_but_close">L\'adresse sélectionnée n\'est pas sur un parcours de livraison…\nMais pas loin !\nVous pouvez faire une demande par email pour prendre en charge votre ville en livraison !</string>
     <string name="auto_geoloc_street_not_covered">Nous livrons bien à %1$s, mais cette commune est partagée entre deux tournées et nous n\'avons pas pu déterminer la vôtre à partir de votre rue.\nEnvoyez-nous un email : nous vous répondrons avec votre jour de livraison.</string>
+    <string name="auto_geoloc_multiple_paths">Bonne nouvelle : nous passons plusieurs fois par semaine à %1$s !\nChoisissez simplement la date de livraison qui vous arrange.</string>
     <string name="manual_path_chosen">L\'adresse sélectionnée vous permet d\'être livré le %1s.</string>
     <string name="delivery_date_label">Date de livraison</string>
     <string name="mapbox_style_URL" translatable="false">mapbox://styles/marchaldevelopment/cm1gh7eih002r01pe96i52fga</string>

--- a/delivery/presentation/src/test/java/com/mtdevelopment/delivery/presentation/viewmodel/DeliveryViewModelTest.kt
+++ b/delivery/presentation/src/test/java/com/mtdevelopment/delivery/presentation/viewmodel/DeliveryViewModelTest.kt
@@ -7,6 +7,7 @@ import com.mtdevelopment.core.usecase.GetAutocompleteSuggestionsUseCase
 import com.mtdevelopment.core.usecase.GetIsNetworkConnectedUseCase
 import com.mtdevelopment.core.usecase.SaveToDatastoreUseCase
 import com.mtdevelopment.delivery.domain.model.DeliveryPath
+import com.mtdevelopment.delivery.domain.usecase.DeliveryEligibility
 import com.mtdevelopment.delivery.domain.usecase.GetAllDeliveryPathsUseCase
 import com.mtdevelopment.delivery.domain.usecase.GetDeliveryPathUseCase
 import com.mtdevelopment.delivery.domain.usecase.GetUserInfoFromDatastoreUseCase
@@ -27,6 +28,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -254,5 +256,152 @@ class DeliveryViewModelTest {
         assertEquals("Pontarlier", state.userCity)
         assertTrue(state.userLocationOnPath)
         assertTrue(state.userLocationCloseFromPath)
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Eligibility verdicts and multi-tournée candidates
+    ///////////////////////////////////////////////////////////////////////////
+
+    private val otherPath = uiPath.copy(id = "2", name = "Tournée du Jeudi", deliveryDay = "Jeudi")
+
+    @Test
+    fun `a single candidate is selected outright`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel()
+
+        viewModel.updateCandidatePaths(listOf(uiPath))
+
+        assertEquals(listOf(uiPath), viewModel.deliveryUiDataState.candidatePaths)
+        assertEquals(uiPath, viewModel.deliveryUiDataState.selectedPath)
+    }
+
+    /** The date picker is what settles it, so nothing must be preselected on the customer's behalf. */
+    @Test
+    fun `several candidates leave the path unselected`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel()
+
+        viewModel.updateCandidatePaths(listOf(uiPath, otherPath))
+
+        assertEquals(listOf(uiPath, otherPath), viewModel.deliveryUiDataState.candidatePaths)
+        assertNull(viewModel.deliveryUiDataState.selectedPath)
+    }
+
+    @Test
+    fun `several candidates keep a previous pick that is still on offer`() =
+        runTest(testDispatcher) {
+            val viewModel = buildViewModel()
+            viewModel.updateSelectedPath(otherPath)
+
+            viewModel.updateCandidatePaths(listOf(uiPath, otherPath))
+
+            assertEquals(otherPath, viewModel.deliveryUiDataState.selectedPath)
+        }
+
+    @Test
+    fun `a previous pick that no longer serves the address is dropped`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel()
+        viewModel.updateSelectedPath(otherPath)
+
+        viewModel.updateCandidatePaths(listOf(uiPath))
+
+        assertEquals(uiPath, viewModel.deliveryUiDataState.selectedPath)
+    }
+
+    @Test
+    fun `no candidate clears the selection`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel()
+        viewModel.updateSelectedPath(uiPath)
+
+        viewModel.updateCandidatePaths(emptyList())
+
+        assertTrue(viewModel.deliveryUiDataState.candidatePaths.isEmpty())
+        assertNull(viewModel.deliveryUiDataState.selectedPath)
+    }
+
+    @Test
+    fun `a deliverable verdict marks the customer as on a path`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel()
+
+        viewModel.updateEligibility(DeliveryEligibility.DELIVERABLE)
+
+        val state = viewModel.deliveryUiDataState
+        assertTrue(state.userLocationOnPath)
+        assertFalse(state.userLocationCloseFromPath)
+        assertFalse(state.streetNotCovered)
+    }
+
+    /**
+     * The uncovered-street verdict shares the support affordance with a near miss but carries its
+     * own wording, hence both flags.
+     */
+    @Test
+    fun `an uncovered street offers support with its own wording`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel()
+
+        viewModel.updateEligibility(DeliveryEligibility.STREET_NOT_COVERED)
+
+        val state = viewModel.deliveryUiDataState
+        assertFalse(state.userLocationOnPath)
+        assertTrue(state.userLocationCloseFromPath)
+        assertTrue(state.streetNotCovered)
+    }
+
+    /** Regression: the flag used to survive a later, deliverable address. */
+    @Test
+    fun `a deliverable address clears a previous uncovered-street verdict`() =
+        runTest(testDispatcher) {
+            val viewModel = buildViewModel()
+            viewModel.updateEligibility(DeliveryEligibility.STREET_NOT_COVERED)
+
+            viewModel.updateEligibility(DeliveryEligibility.DELIVERABLE)
+
+            assertFalse(viewModel.deliveryUiDataState.streetNotCovered)
+        }
+
+    @Test
+    fun `an out-of-range address is neither on a path nor eligible for support`() =
+        runTest(testDispatcher) {
+            val viewModel = buildViewModel()
+
+            viewModel.updateEligibility(DeliveryEligibility.NOT_ELIGIBLE)
+
+            val state = viewModel.deliveryUiDataState
+            assertFalse(state.userLocationOnPath)
+            assertFalse(state.userLocationCloseFromPath)
+            assertFalse(state.streetNotCovered)
+        }
+
+    /**
+     * A pending multi-tournée choice must not read as a validation failure: the name and address
+     * are complete, only the path is still open, and the date picker closes it.
+     */
+    @Test
+    fun `saveUserInfo persists while several tournees are still in the running`() =
+        runTest(testDispatcher) {
+            coEvery { getUserInfoFromDatastoreUseCase.invoke() } returns flowOf(null)
+            val viewModel = buildViewModel()
+            viewModel.setUserNameFieldText("Jean Test")
+            viewModel.setAddressFieldText("1 rue des Tests, 25300 Pontarlier")
+            viewModel.updateCandidatePaths(listOf(uiPath, otherPath))
+            var errored = false
+
+            viewModel.saveUserInfo(onError = { errored = true })
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertFalse(errored)
+            coVerify { saveToDatastoreUseCase.invoke(userInformation = any()) }
+        }
+
+    @Test
+    fun `saveUserInfo still refuses when no path serves the address`() = runTest(testDispatcher) {
+        coEvery { getUserInfoFromDatastoreUseCase.invoke() } returns flowOf(null)
+        val viewModel = buildViewModel()
+        viewModel.setUserNameFieldText("Jean Test")
+        viewModel.setAddressFieldText("1 rue des Tests, 13001 Marseille")
+        var errored = false
+
+        viewModel.saveUserInfo(onError = { errored = true })
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(errored)
     }
 }


### PR DESCRIPTION
PR 1/3 du chantier « règles rues/villes + écran admin ». Elle ne touche que le moteur de décision et le parcours client — l'écran admin plein écran suit dans une PR séparée.

## Ce que ça corrige

La PR #59 avait rendu le split d'une commune entre deux tournées possible dans le modèle. Trois trous restaient côté résolution, et les trois atteignaient de vraies commandes.

**1. Le choix se faisait dans l'ordre de la liste.** Quand deux parcours couvraient une commune sans contrainte de rue, `firstOrNull()` tranchait — c'est-à-dire l'ordre d'itération des documents Firestore. Le client tombait sur une tournée arbitraire, sans moyen d'en changer, et pas forcément la même deux fois de suite.

**2. Le flux « adresse tapée » n'appliquait jamais le verdict.** Il posait les deux booléens legacy à la main au lieu d'appeler `updateEligibility`, donc `streetNotCovered` n'y était jamais levé et le `when` tombait dans `else -> {}`. Un client d'une rue non couverte d'une commune splittée — qui avait tapé son adresse, soit le cas courant — **ne voyait aucun bouton** : ni « Continuer », ni la demande de prise en charge. Le flux GPS, lui, était correct.

**3. Les rues matchaient par préfixe.** Avec « Rue du Moulin » sur un parcours et « Rue du Moulin Neuf » sur l'autre, une adresse à Moulin Neuf contient les deux libellés et matchait les deux parcours.

## La règle, telle qu'implémentée

Pour une commune donnée, N parcours la contenant :

| Cas | Résultat |
|---|---|
| La rue figure dans un seul parcours | Ce parcours (un match de rue bat toujours une ville entière) |
| La rue figure dans plusieurs, libellés de longueurs différentes | Le libellé le plus long gagne |
| La rue figure dans plusieurs, à égalité | **Choix client** |
| Aucun match de rue, ≥1 parcours sans contrainte | Ce parcours ; **plusieurs → choix client** |
| Aucun match, **tous** les parcours contraignent la commune (y compris N=1) | `STREET_NOT_COVERED` → message + bouton « Demander l'ajout de ma rue » |
| Aucun parcours ne couvre la commune, < 5 km | `ASK_FOR_SUPPORT` (inchangé) |
| Au-delà | `NOT_ELIGIBLE` (inchangé) |

Aucune égalité n'est plus résolue silencieusement. Un parcours seul qui contraint la commune renvoie quand même vers l'admin : une liste de rues est une affirmation délibérée que le reste de la commune n'est pas desservi.

## Le choix côté client

Les dates des parcours candidats sont fusionnées dans un seul calendrier, triées chronologiquement ; la date choisie assigne le parcours. Le nom de la tournée n'apparaît sur les tuiles que s'il y a effectivement quelque chose à choisir. Deux parcours livrant le même jour se réduisent à une tuile — la commande ne porte que la date, il n'y aurait rien pour les distinguer.

Le calcul des dates sort du Composable vers `BuildSelectableDeliveryDatesUseCase` : l'arithmétique de parité de semaine et la clôture à J-1 midi y étaient hors de portée des tests.

## Schéma Firestore

**Inchangé.** `Order` ne porte toujours que `deliveryDate`. Contrepartie assumée : si deux parcours candidats partagent jour + fréquence, le choix du client n'a pas de portée opérationnelle — d'où le dédoublonnage des tuiles.

## Vérification

- `:delivery:domain` — 25 tests d'éligibilité (14 existants + 11 nouveaux, un par ligne du tableau), 10 sur le calcul des dates. Verts.
- `:delivery:presentation` — 20 tests ViewModel (9 existants + 11 nouveaux), dont le mapping des verdicts qui n'était pas couvert. Verts.
- `testClientDebugUnitTest` complet : seuls les 2 `AdminViewModelTest` connus rouges au HEAD échouent (upload d'image produit, sans rapport).
- `assembleClientDebug assembleAdminDebug` : OK.

Pas de vérification bout-en-bout sur device : créer une commune splittée de test demanderait d'écrire dans le Firestore de prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)