### PR TITLE
Initialize the Rive runtime where the view is actually built

### DIFF
--- a/core/presentation/src/main/java/com/mtdevelopment/core/presentation/composable/RiveAnimation.kt
+++ b/core/presentation/src/main/java/com/mtdevelopment/core/presentation/composable/RiveAnimation.kt
@@ -1,5 +1,7 @@
 package com.mtdevelopment.core.presentation.composable
 
+import android.content.Context
+import android.util.Log
 import androidx.annotation.RawRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -9,10 +11,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
@@ -29,8 +33,75 @@ import app.rive.runtime.kotlin.core.Alignment
 import app.rive.runtime.kotlin.core.Fit
 import app.rive.runtime.kotlin.core.Loop
 import app.rive.runtime.kotlin.core.PlayableInstance
+import app.rive.runtime.kotlin.core.Rive
 import com.mtdevelopment.core.presentation.R
 import me.rmyhal.contentment.ContentLoadingIndicator
+
+/**
+ * Process-wide, one-shot initialization of the Rive runtime.
+ *
+ * rive-android ships an `androidx.startup` initializer (`RiveInitializer`) but its own AAR
+ * manifest removes the meta-data that registers it (`tools:node="remove"` — verified in
+ * 9.6.5, 10.5.3 and 11.1.2). Nothing therefore auto-loads `librive-android.so`: calling
+ * [Rive.init] is the application's job. Constructing a [RiveAnimationView] beforehand dies
+ * with `UnsatisfiedLinkError: No implementation found for ... FileAssetLoader.constructor()`
+ * the moment the view builds its asset loader.
+ *
+ * That initialization used to live in the home and delivery screens, which made a loaded
+ * native library a property of the *navigation history* rather than of the process. Any
+ * composition that reached a Rive overlay without those screens having run first crashed —
+ * most plausibly after process death, since Compose Navigation restores the back stack and
+ * composes only the destination the user was on, never the start destination. Anchoring the
+ * call to [RiveAnimation] — the only composable in the app that builds a [RiveAnimationView] —
+ * makes the guarantee structural instead of incidental.
+ *
+ * Kept private on purpose: [RiveAnimation] is the only place in the app that instantiates a
+ * Rive view, so there is no legitimate caller that could need to initialize without one.
+ */
+private object RiveRuntime {
+
+    private const val TAG = "RiveRuntime"
+
+    @Volatile
+    private var initialized = false
+
+    @Volatile
+    private var available = false
+
+    /**
+     * Loads the Rive native library once per process and reports whether a
+     * [RiveAnimationView] can now be built. Cheap (a volatile read) on every call after the
+     * first; the lock exists so a second thread cannot start building a view while the
+     * library is still being loaded.
+     *
+     * Uses the application context: [Rive.init] hands it to ReLinker, which may keep it for
+     * the lifetime of the load, and an Activity context has no business being retained there.
+     *
+     * A failure is swallowed on purpose. This animation is decoration on top of a loading
+     * state — a device that cannot load `librive-android.so` (an ABI the store served wrong,
+     * a ReLinker extraction failure on a full disk) must lose the goat, not the checkout.
+     * The attempt is never repeated: a native library that failed to load once will not load
+     * on the next frame either, and retrying would re-throw on every single recomposition.
+     */
+    fun ensureInitialized(context: Context): Boolean {
+        if (initialized) return available
+        return synchronized(this) {
+            if (!initialized) {
+                try {
+                    Rive.init(context.applicationContext)
+                    available = true
+                } catch (throwable: Throwable) {
+                    // Throwable rather than Exception: a missing native symbol arrives as
+                    // UnsatisfiedLinkError, which is an Error.
+                    Log.e(TAG, "Rive runtime unavailable, falling back to a static overlay", throwable)
+                    available = false
+                }
+                initialized = true
+            }
+            available
+        }
+    }
+}
 
 @Suppress("LongMethod")
 @Composable
@@ -115,6 +186,13 @@ fun RiveAnimation(
                         (notifyStop != null)
             }
 
+            // Initialized here rather than in the AndroidView factory: the factory runs
+            // during applyChanges and cannot change what gets composed, so it has no way to
+            // fall back when the native runtime is missing. `remember` pins the verdict for
+            // the lifetime of this overlay; the call itself is idempotent process-wide.
+            val localContext = LocalContext.current
+            val isRiveAvailable = remember { RiveRuntime.ensureInitialized(localContext) }
+
             Box(
                 modifier = Modifier,
                 contentAlignment = androidx.compose.ui.Alignment.Center
@@ -125,32 +203,45 @@ fun RiveAnimation(
                         .background(Color.Black.copy(alpha = 0.8f))
                 )
 
-                AndroidView(
-                    modifier = modifier
-                        .then(semantics)
-                        .clipToBounds(),
-                    factory = { context ->
-                        riveAnimationView = RiveAnimationView(context).apply {
-                            setRiveResource(
-                                resId = resId,
-                                artboardName = artboardName,
-                                animationName = animationName,
-                                stateMachineName = stateMachineName,
-                                autoplay = autoplay,
-                                fit = fit,
-                                loop = loop,
-                                alignment = alignment
-                            )
+                if (isRiveAvailable) {
+                    AndroidView(
+                        modifier = modifier
+                            .then(semantics)
+                            .clipToBounds(),
+                        factory = { context ->
+                            riveAnimationView = RiveAnimationView(context).apply {
+                                setRiveResource(
+                                    resId = resId,
+                                    artboardName = artboardName,
+                                    animationName = animationName,
+                                    stateMachineName = stateMachineName,
+                                    autoplay = autoplay,
+                                    fit = fit,
+                                    loop = loop,
+                                    alignment = alignment
+                                )
+                            }
+                            listener?.let {
+                                riveAnimationView?.registerListener(it)
+                            }
+                            riveAnimationView!!
+                        },
+                        update = {
+                            update.invoke(it)
                         }
-                        listener?.let {
-                            riveAnimationView?.registerListener(it)
-                        }
-                        riveAnimationView!!
-                    },
-                    update = {
-                        update.invoke(it)
-                    }
-                )
+                    )
+                } else {
+                    // Degraded overlay: the scrim above still blocks the screen and reads as
+                    // "busy", which is the part of this component that carries the meaning.
+                    // The animation is the only thing lost.
+                    Image(
+                        modifier = Modifier
+                            .size(100.dp)
+                            .then(semantics),
+                        painter = painterResource(id = R.drawable.placeholder),
+                        contentDescription = contentDescription
+                    )
+                }
             }
 
             DisposableEffect(lifecycleOwner) {

--- a/delivery/presentation/src/admin/java/com/mtdevelopment/delivery/presentation/screen/DeliveryOptionScreen.kt
+++ b/delivery/presentation/src/admin/java/com/mtdevelopment/delivery/presentation/screen/DeliveryOptionScreen.kt
@@ -16,9 +16,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import app.rive.runtime.kotlin.core.Rive
 import com.mapbox.common.MapboxOptions
 import com.mtdevelopment.core.presentation.composable.ErrorOverlay
 import com.mtdevelopment.core.presentation.composable.RiveAnimation
@@ -44,8 +42,6 @@ fun DeliveryOptionScreen(
 
     val deliveryViewModel = koinViewModel<DeliveryViewModel>()
 
-    val context = LocalContext.current
-
     val state = remember(deliveryViewModel.deliveryUiDataState) {
         derivedStateOf {
             deliveryViewModel.deliveryUiDataState
@@ -63,7 +59,6 @@ fun DeliveryOptionScreen(
 
     LaunchedEffect(Unit) {
         deliveryViewModel.loadAdminData()
-        Rive.init(context)
     }
 
     LaunchedEffect(pathsChanged) {

--- a/delivery/presentation/src/client/java/com/mtdevelopment/delivery/presentation/screen/DeliveryOptionScreen.kt
+++ b/delivery/presentation/src/client/java/com/mtdevelopment/delivery/presentation/screen/DeliveryOptionScreen.kt
@@ -15,9 +15,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import app.rive.runtime.kotlin.core.Rive
 import com.mapbox.common.MapboxOptions
 import com.mtdevelopment.core.presentation.composable.ErrorOverlay
 import com.mtdevelopment.core.presentation.composable.RiveAnimation
@@ -48,8 +46,6 @@ fun DeliveryOptionScreen(
     navigateToCheckout: () -> Unit = {},
     navigateBack: () -> Unit = {}
 ) {
-    val context = LocalContext.current
-
     val deliveryViewModel = koinViewModel<DeliveryViewModel>()
     val isConnected = deliveryViewModel.isConnected.collectAsState()
 
@@ -72,7 +68,6 @@ fun DeliveryOptionScreen(
     }
 
     LaunchedEffect(Unit) {
-        Rive.init(context)
         deliveryViewModel.loadClientData()
     }
 

--- a/home/presentation/src/admin/java/com/mtdevelopment/home/presentation/composable/HomeScreen.kt
+++ b/home/presentation/src/admin/java/com/mtdevelopment/home/presentation/composable/HomeScreen.kt
@@ -24,9 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import app.rive.runtime.kotlin.core.Rive
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mtdevelopment.admin.presentation.composable.ProductEditDialog
 import com.mtdevelopment.admin.presentation.viewmodel.AdminViewModel
@@ -53,8 +51,6 @@ fun HomeScreen(
     navigateToDelivery: () -> Unit = {},
     navigateToOrders: () -> Unit = {}
 ) {
-    val context = LocalContext.current
-
     val homeViewModel = koinViewModel<HomeViewModel>()
     val adminViewModel = koinViewModel<AdminViewModel>()
 
@@ -69,10 +65,6 @@ fun HomeScreen(
         if (hasLoadedFirstPic) {
             mainViewModel.setCanRemoveSplash()
         }
-    }
-
-    LaunchedEffect(Unit) {
-        Rive.init(context)
     }
 
     // Manual refresh handling

--- a/home/presentation/src/client/java/com/mtdevelopment/home/presentation/composable/HomeScreen.kt
+++ b/home/presentation/src/client/java/com/mtdevelopment/home/presentation/composable/HomeScreen.kt
@@ -40,10 +40,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import app.rive.runtime.kotlin.core.Rive
 import com.mtdevelopment.cart.presentation.viewmodel.CartViewModel
 import com.mtdevelopment.core.presentation.MainViewModel
 import com.mtdevelopment.core.presentation.composable.ErrorOverlay
@@ -64,7 +62,6 @@ fun HomeScreen(
     navigateToOrders: () -> Unit = {}
 ) {
     val coroutineScope = rememberCoroutineScope()
-    val context = LocalContext.current
 
     val homeViewModel = koinViewModel<HomeViewModel>()
 
@@ -106,10 +103,6 @@ fun HomeScreen(
         if (hasLoadedFirstPic) {
             mainViewModel.setCanRemoveSplash()
         }
-    }
-
-    LaunchedEffect(Unit) {
-        Rive.init(context)
     }
 
     // React to manual refresh requests


### PR DESCRIPTION
Fixes the first Crashlytics crash since the store release (2 days ago).

```
Fatal Exception: java.lang.UnsatisfiedLinkError: No implementation found for
long app.rive.runtime.kotlin.core.FileAssetLoader.constructor() ...
  at app.rive.runtime.kotlin.RiveAnimationView.<init>(RiveAnimationView.kt:385)
  at com.mtdevelopment.core.presentation.composable.RiveAnimationKt.RiveAnimation$lambda$1$3$0(RiveAnimation.kt:133)
```

## Why

`librive-android.so` was never loaded in that process, because **rive-android does not load it for you**. Its AAR manifest registers the `androidx.startup` provider but strips its own initializer out of it:

```xml
<meta-data android:name="app.rive.runtime.kotlin.RiveInitializer"
           android:value="androidx.startup"
           tools:node="remove" />
```

Verified by unzipping the 9.6.5, 10.5.3 and **11.1.2** artifacts from Maven Central — identical in all three, so this is not a regression from a version bump. `javap` on `Rive.class` confirms `Rive.init()` is the only path to `ReLinker.loadLibrary("rive-android")`.

We called `Rive.init` in exactly **four** places, all inside a `LaunchedEffect` in a composable (both `HomeScreen`s, both `DeliveryOptionScreen`s). There are **ten** `RiveAnimation` call sites. A loaded native library was therefore a property of the *navigation history*, not of the process.

The likeliest path a customer takes to the crash: process death, after which Compose Navigation restores the back stack and composes only the destination they were on — Checkout or Detail — never the start destination. The first loading overlay then dies.

## What changed

- `core/presentation/.../RiveAnimation.kt`: a private `RiveRuntime` object with a double-checked `@Volatile` guard, called from `RiveAnimation` itself — the only composable in the app that builds a `RiveAnimationView` (verified by grep over `.kt` and `.xml`: no layout, no other module, no direct construction).
- A failed init is now logged, never retried, and the overlay degrades to the static placeholder behind the same scrim. The screen still blocks and still reads as busy. This animation is decoration on top of a loading state; a bad native load should cost the goat, not the checkout.
- Removed the four scattered `Rive.init` calls and their now-unused imports.

**Ruled out while diagnosing:** R8 renaming (the crash message carries the unobfuscated class name, and the AAR ships `-keep class app.rive.**`), missing ABI (all four are in the artifact), dlopen/16 KB-page failure (the error is a missing symbol, not a failed load).

## Verification

- `:app:compileClientDebugKotlin` and `:app:compileAdminDebugKotlin` both green — both flavors build.
- No unit tests added: this is a native-lib/process-level concern. The repo's 18 instrumented tests are all `ExampleInstrumentedTest` stubs, and `connectedAdminDebugAndroidTest` on `delivery/presentation` is still blocked by the Rive/Mapbox `libc++_shared.so` merge conflict (see `fromagerie-validation-and-qa`).
- Reviewed by a skeptical review agent: verdict PASS, no blocking findings. It independently re-verified the AAR manifest, the `javap` output, the single construction site, and the double-checked locking.

**NOT verified on device.** The repro to run before merging:

1. Navigate to Checkout.
2. `adb shell am force-stop com.mtdevelopment.lafromagerie`
3. Relaunch from Recents and trigger a loader.

It should crash on the released build and not on this one. Tommy is running this himself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)