### PR TITLE
Order reminders on the delivery day (lot 0) + click & collect spec

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -162,6 +162,9 @@ dependencies {
     implementation(libs.firebase.firestore)
     // Client-only: push notifications (the admin flavor has no FCM consumer).
     "clientImplementation"(libs.firebase.messaging)
+    // Client-only: the order-reminder worker. The admin flavor binds a no-op scheduler and
+    // never touches WorkManager from this module.
+    "clientImplementation"(libs.androidx.work.runtime)
 
     ksp(libs.room.compiler)
     implementation(libs.room.ktx)

--- a/app/src/admin/java/com/mtdevelopment/lafromagerie/NoOpOrderReminderScheduler.kt
+++ b/app/src/admin/java/com/mtdevelopment/lafromagerie/NoOpOrderReminderScheduler.kt
@@ -1,0 +1,21 @@
+package com.mtdevelopment.lafromagerie
+
+import com.mtdevelopment.checkout.domain.repository.OrderReminderScheduler
+
+/**
+ * Admin-flavor binding for [OrderReminderScheduler].
+ *
+ * The admin flavor reaches the checkout screen too, so `CheckoutViewModel` — and through
+ * it `ScheduleOrderReminderUseCase` — is instantiated here as well. Koin resolves
+ * definitions at runtime, so leaving this unbound would not fail the build: it would
+ * crash the shop owner's app the first time he opened checkout.
+ *
+ * Doing nothing is the correct behaviour, not a stub: an order the owner puts through
+ * himself has no customer device to remind.
+ */
+class NoOpOrderReminderScheduler : OrderReminderScheduler {
+
+    override fun scheduleReminder(orderId: String, deliveryDate: String) = Unit
+
+    override fun cancelReminder(orderId: String) = Unit
+}

--- a/app/src/admin/java/com/mtdevelopment/lafromagerie/di/FlavorModules.kt
+++ b/app/src/admin/java/com/mtdevelopment/lafromagerie/di/FlavorModules.kt
@@ -4,7 +4,9 @@ import com.mtdevelopment.admin.data.di.adminDataModule
 import com.mtdevelopment.admin.domain.di.adminDomainModule
 import com.mtdevelopment.admin.presentation.di.adminPresentationModule
 import com.mtdevelopment.auth.di.authModule
+import com.mtdevelopment.checkout.domain.repository.OrderReminderScheduler
 import com.mtdevelopment.lafromagerie.DeliveryTrackingService
+import com.mtdevelopment.lafromagerie.NoOpOrderReminderScheduler
 import org.koin.dsl.module
 
 fun flavorModules() =
@@ -14,4 +16,8 @@ val mainModule = module {
     single<DeliveryTrackingService> {
         DeliveryTrackingService()
     }
+
+    // The admin flavor also reaches checkout, so this definition must exist here too:
+    // Koin would otherwise crash at runtime rather than fail the build.
+    single<OrderReminderScheduler> { NoOpOrderReminderScheduler() }
 }

--- a/app/src/client/java/com/mtdevelopment/lafromagerie/di/FlavorModules.kt
+++ b/app/src/client/java/com/mtdevelopment/lafromagerie/di/FlavorModules.kt
@@ -1,7 +1,9 @@
 package com.mtdevelopment.lafromagerie.di
 
+import com.mtdevelopment.checkout.domain.repository.OrderReminderScheduler
 import com.mtdevelopment.lafromagerie.notifications.NotificationLocalStore
 import com.mtdevelopment.lafromagerie.notifications.NotificationViewModel
+import com.mtdevelopment.lafromagerie.notifications.WorkManagerOrderReminderScheduler
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.dsl.module
@@ -10,7 +12,11 @@ fun flavorModules() = listOf(flavorModules)
 
 val flavorModules = module {
     // single: two DataStore instances on the same file crash at runtime, and the store is
-    // shared between ClientMessagingService and NotificationViewModel.
+    // shared between ClientMessagingService, OrderReminderWorker and NotificationViewModel.
     single { NotificationLocalStore(androidContext(), get()) }
     viewModelOf(::NotificationViewModel)
+
+    // Local order reminders. The admin flavor binds a no-op counterpart — both flavors
+    // must provide one, since Koin only discovers a missing definition at runtime.
+    single<OrderReminderScheduler> { WorkManagerOrderReminderScheduler(androidContext()) }
 }

--- a/app/src/client/java/com/mtdevelopment/lafromagerie/notifications/ClientMessagingService.kt
+++ b/app/src/client/java/com/mtdevelopment/lafromagerie/notifications/ClientMessagingService.kt
@@ -1,15 +1,8 @@
 package com.mtdevelopment.lafromagerie.notifications
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.app.PendingIntent
-import android.content.Intent
 import android.util.Log
-import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
-import com.mtdevelopment.lafromagerie.MainActivity
 import com.mtdevelopment.lafromagerie.R
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -58,7 +51,7 @@ class ClientMessagingService : FirebaseMessagingService(), KoinComponent {
             }
         }
 
-        postSystemNotification(notification)
+        ClientNotifier.post(this, notification)
     }
 
     override fun onNewToken(token: String) {
@@ -72,52 +65,8 @@ class ClientMessagingService : FirebaseMessagingService(), KoinComponent {
         super.onDestroy()
     }
 
-    private fun postSystemNotification(notification: InAppNotification) {
-        val manager = NotificationManagerCompat.from(this)
-        if (!manager.areNotificationsEnabled()) {
-            Log.i(TAG, "postSystemNotification: notifications disabled by user, in-app only")
-            return
-        }
-
-        manager.createNotificationChannel(
-            NotificationChannel(
-                CHANNEL_ID,
-                CHANNEL_NAME,
-                NotificationManager.IMPORTANCE_DEFAULT
-            )
-        )
-
-        val contentIntent = PendingIntent.getActivity(
-            this,
-            0,
-            Intent(this, MainActivity::class.java).apply {
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            },
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-        )
-
-        val systemNotification = NotificationCompat.Builder(this, CHANNEL_ID)
-            .setSmallIcon(R.drawable.appicon_simpler)
-            .setContentTitle(notification.title)
-            .setContentText(notification.body)
-            .setStyle(NotificationCompat.BigTextStyle().bigText(notification.body))
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .setContentIntent(contentIntent)
-            .setAutoCancel(true)
-            .build()
-
-        try {
-            manager.notify(notification.id.hashCode(), systemNotification)
-        } catch (e: SecurityException) {
-            // POST_NOTIFICATIONS revoked between the check and the call.
-            Log.w(TAG, "postSystemNotification:", e)
-        }
-    }
-
     companion object {
         private const val TAG = "ClientMessagingService"
-        const val CHANNEL_ID = "fromagerie_client_general"
-        private const val CHANNEL_NAME = "Actualités et rappels"
         const val TOPIC_ALL_CLIENTS = "clients"
         const val DATA_KEY_TITLE = "title"
         const val DATA_KEY_BODY = "body"

--- a/app/src/client/java/com/mtdevelopment/lafromagerie/notifications/ClientNotifier.kt
+++ b/app/src/client/java/com/mtdevelopment/lafromagerie/notifications/ClientNotifier.kt
@@ -1,0 +1,74 @@
+package com.mtdevelopment.lafromagerie.notifications
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.mtdevelopment.lafromagerie.MainActivity
+import com.mtdevelopment.lafromagerie.R
+
+/**
+ * Single place where the client flavor posts a system notification.
+ *
+ * Shared by the two producers — pushes received through [ClientMessagingService] and
+ * local order reminders raised by [OrderReminderWorker] — so both land on the same
+ * channel, with the same icon and the same tap target. Splitting them would let the two
+ * drift, and the channel id is also declared in the client manifest as FCM's default.
+ */
+internal object ClientNotifier {
+
+    const val CHANNEL_ID = "fromagerie_client_general"
+    private const val CHANNEL_NAME = "Actualités et rappels"
+    private const val TAG = "ClientNotifier"
+
+    /**
+     * Posts [notification] to the system tray. Silently skipped when the user has
+     * revoked notifications: the refusal is respected and the entry still lives in the
+     * in-app notification center.
+     */
+    fun post(context: Context, notification: InAppNotification) {
+        val manager = NotificationManagerCompat.from(context)
+        if (!manager.areNotificationsEnabled()) {
+            Log.i(TAG, "post: notifications disabled by user, in-app only")
+            return
+        }
+
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+        )
+
+        val contentIntent = PendingIntent.getActivity(
+            context,
+            0,
+            Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            },
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val systemNotification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.appicon_simpler)
+            .setContentTitle(notification.title)
+            .setContentText(notification.body)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(notification.body))
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(contentIntent)
+            .setAutoCancel(true)
+            .build()
+
+        try {
+            manager.notify(notification.id.hashCode(), systemNotification)
+        } catch (e: SecurityException) {
+            // POST_NOTIFICATIONS revoked between the check and the call.
+            Log.w(TAG, "post:", e)
+        }
+    }
+}

--- a/app/src/client/java/com/mtdevelopment/lafromagerie/notifications/OrderReminderWorker.kt
+++ b/app/src/client/java/com/mtdevelopment/lafromagerie/notifications/OrderReminderWorker.kt
@@ -1,0 +1,70 @@
+package com.mtdevelopment.lafromagerie.notifications
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/**
+ * Raises the reminder for one order on the morning it is due.
+ *
+ * Enqueued at payment time by [WorkManagerOrderReminderScheduler] and persisted by
+ * WorkManager, so it survives the app being killed and the device rebooting — which an
+ * `AlarmManager` would only match at the cost of the exact-alarm permission introduced in
+ * Android 12.
+ *
+ * The entry is written to the in-app notification center **before** the system
+ * notification is posted: the tray copy can be swiped away or suppressed outright when
+ * the user declined POST_NOTIFICATIONS, and the notification center is then the only
+ * remaining trace.
+ */
+class OrderReminderWorker(
+    appContext: Context,
+    params: WorkerParameters
+) : CoroutineWorker(appContext, params), KoinComponent {
+
+    private val notificationStore: NotificationLocalStore by inject()
+
+    override suspend fun doWork(): Result {
+        val orderId = inputData.getString(KEY_ORDER_ID)
+        if (orderId.isNullOrBlank()) {
+            Log.w(TAG, "doWork: no order id in input, nothing to remind about")
+            return Result.failure()
+        }
+
+        val notification = InAppNotification(
+            // Derived from the order id rather than random: NotificationLocalStore.add
+            // ignores an id it already holds, so a reminder that somehow fires twice for
+            // one order leaves a single entry in the notification center.
+            id = "$NOTIFICATION_ID_PREFIX$orderId",
+            title = TITLE,
+            body = BODY,
+            timestampMillis = System.currentTimeMillis()
+        )
+
+        try {
+            notificationStore.add(notification)
+        } catch (e: Exception) {
+            // The tray notification is still worth posting: a persistence failure must
+            // not swallow the reminder itself.
+            Log.e(TAG, "doWork: persisting reminder for $orderId failed", e)
+        }
+
+        ClientNotifier.post(applicationContext, notification)
+        Log.i(TAG, "doWork: reminder raised for order $orderId")
+        return Result.success()
+    }
+
+    companion object {
+        const val KEY_ORDER_ID = "order_id"
+        const val UNIQUE_WORK_PREFIX = "order_reminder_"
+        private const val NOTIFICATION_ID_PREFIX = "reminder_"
+        private const val TAG = "OrderReminderWorker"
+        private const val TITLE = "Votre commande arrive aujourd'hui"
+        private const val BODY =
+            "Votre commande La Fromagerie est prévue pour aujourd'hui. " +
+                    "Pensez à rester joignable pour la livraison !"
+    }
+}

--- a/app/src/client/java/com/mtdevelopment/lafromagerie/notifications/WorkManagerOrderReminderScheduler.kt
+++ b/app/src/client/java/com/mtdevelopment/lafromagerie/notifications/WorkManagerOrderReminderScheduler.kt
@@ -1,0 +1,64 @@
+package com.mtdevelopment.lafromagerie.notifications
+
+import android.content.Context
+import android.util.Log
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import com.mtdevelopment.checkout.domain.model.OrderReminder
+import com.mtdevelopment.checkout.domain.repository.OrderReminderScheduler
+import java.util.concurrent.TimeUnit
+
+/**
+ * Client-flavor implementation: a persisted WorkManager job per order, fired on the
+ * morning of the delivery day.
+ *
+ * No network constraint — the reminder carries no server data, so it must fire in a cellar
+ * with no signal just as well as anywhere else. WorkManager honours the initial delay but
+ * not to the minute (Doze can defer it); that is deliberate and sufficient for a "today"
+ * reminder, and it avoids the exact-alarm permission an `AlarmManager` would demand.
+ */
+class WorkManagerOrderReminderScheduler(
+    private val context: Context
+) : OrderReminderScheduler {
+
+    override fun scheduleReminder(orderId: String, deliveryDate: String) {
+        val reminderMillis = OrderReminder.reminderTimeMillis(
+            deliveryDate = deliveryDate,
+            nowMillis = System.currentTimeMillis()
+        )
+        if (reminderMillis == null) {
+            // Unparseable date, or a slot already past: staying silent beats reminding
+            // someone about a day that is over.
+            Log.i(TAG, "scheduleReminder: nothing to schedule for $orderId ($deliveryDate)")
+            return
+        }
+
+        val request = OneTimeWorkRequestBuilder<OrderReminderWorker>()
+            .setInitialDelay(reminderMillis - System.currentTimeMillis(), TimeUnit.MILLISECONDS)
+            .setInputData(workDataOf(OrderReminderWorker.KEY_ORDER_ID to orderId))
+            .build()
+
+        // REPLACE keyed on the order: re-finalizing the same payment (in-app flow racing
+        // the durable worker) must not produce two reminders.
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            uniqueWorkName(orderId),
+            ExistingWorkPolicy.REPLACE,
+            request
+        )
+        Log.i(TAG, "scheduleReminder: order $orderId due $deliveryDate")
+    }
+
+    override fun cancelReminder(orderId: String) {
+        WorkManager.getInstance(context).cancelUniqueWork(uniqueWorkName(orderId))
+        Log.i(TAG, "cancelReminder: order $orderId")
+    }
+
+    private fun uniqueWorkName(orderId: String) =
+        "${OrderReminderWorker.UNIQUE_WORK_PREFIX}$orderId"
+
+    private companion object {
+        const val TAG = "OrderReminderScheduler"
+    }
+}

--- a/app/src/main/java/com/mtdevelopment/lafromagerie/di/AppModule.kt
+++ b/app/src/main/java/com/mtdevelopment/lafromagerie/di/AppModule.kt
@@ -17,6 +17,7 @@ import com.mtdevelopment.checkout.data.work.WorkManagerPaymentFinalizationSchedu
 import com.mtdevelopment.checkout.domain.repository.CheckoutDatastorePreference
 import com.mtdevelopment.checkout.domain.repository.PaymentFinalizationScheduler
 import com.mtdevelopment.checkout.domain.repository.PaymentRepository
+import com.mtdevelopment.checkout.domain.usecase.CancelOrderReminderUseCase
 import com.mtdevelopment.checkout.domain.usecase.ClearPendingPaymentFinalizationUseCase
 import com.mtdevelopment.checkout.domain.usecase.CreateNewCheckoutUseCase
 import com.mtdevelopment.checkout.domain.usecase.CreateNewOrderUseCase
@@ -36,6 +37,7 @@ import com.mtdevelopment.checkout.domain.usecase.ResumePendingPaymentFinalizatio
 import com.mtdevelopment.checkout.domain.usecase.SaveCheckoutReferenceUseCase
 import com.mtdevelopment.checkout.domain.usecase.SaveCreatedCheckoutUseCase
 import com.mtdevelopment.checkout.domain.usecase.SavePaymentStateUseCase
+import com.mtdevelopment.checkout.domain.usecase.ScheduleOrderReminderUseCase
 import com.mtdevelopment.checkout.domain.usecase.SchedulePaymentFinalizationUseCase
 import com.mtdevelopment.checkout.domain.usecase.UpdateOrderStatus
 import com.mtdevelopment.checkout.domain.usecase.VerifyHostedCheckoutStatusUseCase
@@ -206,6 +208,11 @@ val mainAppModule = module {
     factory { ResumePendingPaymentFinalizationUseCase(get(), get()) }
     factory { ClearPendingPaymentFinalizationUseCase(get()) }
 
+    // Local order reminders. The OrderReminderScheduler they resolve is flavor-specific
+    // and bound in flavorModules (real one on client, no-op on admin).
+    factory { ScheduleOrderReminderUseCase(get(), get()) }
+    factory { CancelOrderReminderUseCase(get()) }
+
     factory { GetLastFirestoreDatabaseUpdateUseCase(get(), get()) }
 
     factory { GetAllProductsUseCase(get()) }
@@ -244,6 +251,7 @@ val mainAppModule = module {
             getSavedOrderUseCase = get(),
             schedulePaymentFinalizationUseCase = get(),
             clearPendingPaymentFinalizationUseCase = get(),
+            scheduleOrderReminderUseCase = get(),
             getSumUpPaymentLinkUseCase = get(),
             verifyHostedCheckoutStatusUseCase = get()
         )

--- a/checkout/data/src/main/java/com/mtdevelopment/checkout/data/work/FinalizePaymentWorker.kt
+++ b/checkout/data/src/main/java/com/mtdevelopment/checkout/data/work/FinalizePaymentWorker.kt
@@ -10,6 +10,8 @@ import com.mtdevelopment.checkout.data.remote.source.SumUpDataSource
 import com.mtdevelopment.checkout.data.work.FinalizePaymentWorker.Companion.MAX_RUN_ATTEMPTS
 import com.mtdevelopment.checkout.domain.model.PendingPaymentFinalization
 import com.mtdevelopment.checkout.domain.repository.CheckoutDatastorePreference
+import com.mtdevelopment.checkout.domain.usecase.CancelOrderReminderUseCase
+import com.mtdevelopment.checkout.domain.usecase.ScheduleOrderReminderUseCase
 import com.mtdevelopment.core.model.OrderStatus
 import com.mtdevelopment.core.repository.SharedDatastore
 import com.mtdevelopment.core.util.NetWorkResult
@@ -29,9 +31,10 @@ import org.koin.core.component.inject
  * submitted (Google Pay path) or right before the hosted-checkout page is opened
  * (hosted path, where the customer may pay in the browser and never return to the
  * app). It polls SumUp for the terminal status and:
- * - on PAID: marks the Firestore order as PAID and clears the local cart,
- * - on FAILED: marks the Firestore order as CANCELED (the cart is kept so the
- *   customer can retry),
+ * - on PAID: marks the Firestore order as PAID, clears the local cart and schedules the
+ *   delivery-day reminder,
+ * - on FAILED: marks the Firestore order as CANCELED and drops any reminder (the cart is
+ *   kept so the customer can retry),
  * then clears the pending-finalization marker.
  *
  * Every step is idempotent, so it can safely race with the in-app flow: whichever
@@ -46,6 +49,8 @@ class FinalizePaymentWorker(
     private val sumUpDataSource: SumUpDataSource by inject()
     private val firestoreOrderDataSource: FirestoreOrderDataSource by inject()
     private val sharedDatastore: SharedDatastore by inject()
+    private val scheduleOrderReminderUseCase: ScheduleOrderReminderUseCase by inject()
+    private val cancelOrderReminderUseCase: CancelOrderReminderUseCase by inject()
 
     override suspend fun doWork(): Result {
         val pending = checkoutDatastorePreference.pendingFinalizationFlow.first()
@@ -100,8 +105,14 @@ class FinalizePaymentWorker(
             )
         }
 
+        // The reminder follows the order's fate: raised once the delivery is certain,
+        // dropped when the payment failed. Doing it here as well as in the in-app flow is
+        // what makes a payment completed while the app was dead still produce a reminder.
         if (status == OrderStatus.PAID) {
             sharedDatastore.clearCartItems()
+            scheduleOrderReminderUseCase.invoke(pending.orderId)
+        } else {
+            cancelOrderReminderUseCase.invoke(pending.orderId)
         }
         checkoutDatastorePreference.clearPendingFinalization()
         Log.i(TAG, "Order ${pending.orderId} finalized as $status")

--- a/checkout/domain/src/main/java/com/mtdevelopment/checkout/domain/model/OrderReminder.kt
+++ b/checkout/domain/src/main/java/com/mtdevelopment/checkout/domain/model/OrderReminder.kt
@@ -1,0 +1,43 @@
+package com.mtdevelopment.checkout.domain.model
+
+import com.mtdevelopment.core.domain.toLocalDate
+import java.time.ZoneId
+
+/**
+ * Timing rule for the order reminder: when, on the delivery day, the customer is nudged.
+ *
+ * Lives in the domain rather than in the scheduler implementation so the rule is unit
+ * tested without WorkManager or an Android context.
+ */
+object OrderReminder {
+
+    /**
+     * Local hour of the delivery day at which the reminder fires. Early enough to be seen
+     * before a morning tournée, late enough not to wake anyone.
+     */
+    const val REMINDER_HOUR: Int = 8
+
+    /**
+     * Resolves the instant at which the reminder for [deliveryDate] (`dd/MM/yyyy`) should
+     * fire, or null when it should not be scheduled at all.
+     *
+     * Null is returned for an unparseable date and for an instant already past — the two
+     * cases where firing would be worse than staying silent. The zone is the device's:
+     * "8am on delivery day" only means anything in the customer's own time.
+     *
+     * @param nowMillis Current time, injected so the rule is testable.
+     * @param zone Device time zone, injected for the same reason.
+     */
+    fun reminderTimeMillis(
+        deliveryDate: String,
+        nowMillis: Long,
+        zone: ZoneId = ZoneId.systemDefault()
+    ): Long? {
+        val date = deliveryDate.toLocalDate() ?: return null
+        val reminderMillis = date.atTime(REMINDER_HOUR, 0)
+            .atZone(zone)
+            .toInstant()
+            .toEpochMilli()
+        return reminderMillis.takeIf { it > nowMillis }
+    }
+}

--- a/checkout/domain/src/main/java/com/mtdevelopment/checkout/domain/repository/OrderReminderScheduler.kt
+++ b/checkout/domain/src/main/java/com/mtdevelopment/checkout/domain/repository/OrderReminderScheduler.kt
@@ -1,0 +1,28 @@
+package com.mtdevelopment.checkout.domain.repository
+
+/**
+ * Schedules the local, on-device reminder that tells the customer their order is due on
+ * the current day.
+ *
+ * Deliberately local rather than pushed from the server: the app's FCM targeting is
+ * topic-based (every client listens to the same topic, no per-device token registry), so
+ * a per-customer reminder cannot go through it. The delivery date is known at checkout on
+ * the very device that placed the order, which is all the information a reminder needs.
+ *
+ * Implementations are flavor-specific: the client posts a real notification, the admin
+ * flavor does nothing (it shares the checkout screen but has no customer to remind).
+ */
+interface OrderReminderScheduler {
+
+    /**
+     * Schedules the reminder for [orderId], due on [deliveryDate] (`dd/MM/yyyy`).
+     *
+     * Scheduling the same [orderId] twice replaces the previous reminder rather than
+     * adding a second one. A date that resolves to an instant already in the past is
+     * skipped: a reminder for a day that is over would only confuse.
+     */
+    fun scheduleReminder(orderId: String, deliveryDate: String)
+
+    /** Drops a previously scheduled reminder; a no-op when none exists. */
+    fun cancelReminder(orderId: String)
+}

--- a/checkout/domain/src/main/java/com/mtdevelopment/checkout/domain/usecase/CancelOrderReminderUseCase.kt
+++ b/checkout/domain/src/main/java/com/mtdevelopment/checkout/domain/usecase/CancelOrderReminderUseCase.kt
@@ -1,0 +1,15 @@
+package com.mtdevelopment.checkout.domain.usecase
+
+import com.mtdevelopment.checkout.domain.repository.OrderReminderScheduler
+
+/**
+ * Drops the reminder of an order that will never be honoured (payment failed, order
+ * canceled). Safe to call for an order that never had one.
+ */
+class CancelOrderReminderUseCase(
+    private val orderReminderScheduler: OrderReminderScheduler
+) {
+    operator fun invoke(orderId: String) {
+        orderReminderScheduler.cancelReminder(orderId)
+    }
+}

--- a/checkout/domain/src/main/java/com/mtdevelopment/checkout/domain/usecase/ScheduleOrderReminderUseCase.kt
+++ b/checkout/domain/src/main/java/com/mtdevelopment/checkout/domain/usecase/ScheduleOrderReminderUseCase.kt
@@ -1,0 +1,34 @@
+package com.mtdevelopment.checkout.domain.usecase
+
+import com.mtdevelopment.checkout.domain.repository.CheckoutDatastorePreference
+import com.mtdevelopment.checkout.domain.repository.OrderReminderScheduler
+import kotlinx.coroutines.flow.firstOrNull
+
+/**
+ * Schedules the "your order is due today" reminder for the order that was just paid.
+ *
+ * Invoked on the two paths that reach PAID — the in-app one and the durable worker — so
+ * a payment that completes while the app is dead still gets its reminder. Both call it
+ * with the order id they just finalized: the locally saved order is only trusted when it
+ * matches, otherwise a stale leftover from a previous checkout would be reminded about.
+ *
+ * Never invoked on order creation: an order that is never paid must not produce a
+ * reminder, and abandonment leaves no event to cancel one.
+ */
+class ScheduleOrderReminderUseCase(
+    private val checkoutDatastorePreference: CheckoutDatastorePreference,
+    private val orderReminderScheduler: OrderReminderScheduler
+) {
+    /**
+     * @param expectedOrderId The order just marked PAID.
+     * @return true when a reminder was handed to the scheduler.
+     */
+    suspend operator fun invoke(expectedOrderId: String): Boolean {
+        val order = checkoutDatastorePreference.orderFlow.firstOrNull()
+            ?: return false
+        if (order.id != expectedOrderId || order.deliveryDate.isBlank()) return false
+
+        orderReminderScheduler.scheduleReminder(order.id, order.deliveryDate)
+        return true
+    }
+}

--- a/checkout/domain/src/test/java/com/mtdevelopment/checkout/domain/model/OrderReminderTest.kt
+++ b/checkout/domain/src/test/java/com/mtdevelopment/checkout/domain/model/OrderReminderTest.kt
@@ -1,0 +1,90 @@
+package com.mtdevelopment.checkout.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+
+class OrderReminderTest {
+
+    private val paris: ZoneId = ZoneId.of("Europe/Paris")
+
+    private fun millisAt(date: String, hour: Int, minute: Int = 0): Long {
+        val (day, month, year) = date.split("/").map { it.toInt() }
+        return LocalDate.of(year, month, day)
+            .atTime(LocalTime.of(hour, minute))
+            .atZone(paris)
+            .toInstant()
+            .toEpochMilli()
+    }
+
+    @Test
+    fun `reminder fires at 8am local time on the delivery day`() {
+        val actual = OrderReminder.reminderTimeMillis(
+            deliveryDate = "15/08/2026",
+            nowMillis = millisAt("10/08/2026", hour = 12),
+            zone = paris
+        )
+
+        assertEquals(millisAt("15/08/2026", hour = OrderReminder.REMINDER_HOUR), actual)
+    }
+
+    @Test
+    fun `a delivery day already over is not scheduled`() {
+        val actual = OrderReminder.reminderTimeMillis(
+            deliveryDate = "01/08/2026",
+            nowMillis = millisAt("10/08/2026", hour = 12),
+            zone = paris
+        )
+
+        assertNull(actual)
+    }
+
+    @Test
+    fun `today past the reminder hour is not scheduled`() {
+        // Reminding someone at noon that their order arrives "today at 8am" is noise:
+        // the slot is gone, so nothing is enqueued.
+        val actual = OrderReminder.reminderTimeMillis(
+            deliveryDate = "10/08/2026",
+            nowMillis = millisAt("10/08/2026", hour = 12),
+            zone = paris
+        )
+
+        assertNull(actual)
+    }
+
+    @Test
+    fun `today before the reminder hour is still scheduled`() {
+        val actual = OrderReminder.reminderTimeMillis(
+            deliveryDate = "10/08/2026",
+            nowMillis = millisAt("10/08/2026", hour = 6),
+            zone = paris
+        )
+
+        assertEquals(millisAt("10/08/2026", hour = OrderReminder.REMINDER_HOUR), actual)
+    }
+
+    @Test
+    fun `an unparseable date is not scheduled`() {
+        val actual = OrderReminder.reminderTimeMillis(
+            deliveryDate = "2026-08-15",
+            nowMillis = millisAt("10/08/2026", hour = 12),
+            zone = paris
+        )
+
+        assertNull(actual)
+    }
+
+    @Test
+    fun `a blank date is not scheduled`() {
+        val actual = OrderReminder.reminderTimeMillis(
+            deliveryDate = "",
+            nowMillis = millisAt("10/08/2026", hour = 12),
+            zone = paris
+        )
+
+        assertNull(actual)
+    }
+}

--- a/checkout/domain/src/test/java/com/mtdevelopment/checkout/domain/usecase/OrderReminderUseCasesTest.kt
+++ b/checkout/domain/src/test/java/com/mtdevelopment/checkout/domain/usecase/OrderReminderUseCasesTest.kt
@@ -1,0 +1,91 @@
+package com.mtdevelopment.checkout.domain.usecase
+
+import com.mtdevelopment.checkout.domain.repository.CheckoutDatastorePreference
+import com.mtdevelopment.checkout.domain.repository.OrderReminderScheduler
+import com.mtdevelopment.core.model.Order
+import com.mtdevelopment.core.model.OrderStatus
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class OrderReminderUseCasesTest {
+
+    private val preferences: CheckoutDatastorePreference = mockk()
+    private val scheduler: OrderReminderScheduler = mockk()
+
+    @Before
+    fun setUp() {
+        every { scheduler.scheduleReminder(any(), any()) } just Runs
+        every { scheduler.cancelReminder(any()) } just Runs
+    }
+
+    private fun order(id: String = "order-1", deliveryDate: String = "15/08/2026") = Order(
+        id = id,
+        customerName = "Jean Dupont",
+        customerAddress = "1 rue du Comté, 25300 Pontarlier",
+        customerBillingAddress = "1 rue du Comté, 25300 Pontarlier",
+        deliveryDate = deliveryDate,
+        orderDate = "10/08/2026",
+        products = mapOf("Comté AOP" to 2),
+        status = OrderStatus.PAID,
+        note = null
+    )
+
+    @Test
+    fun `schedules the reminder for the order that was just paid`() = runTest {
+        coEvery { preferences.orderFlow } returns flowOf(order())
+
+        val scheduled = ScheduleOrderReminderUseCase(preferences, scheduler).invoke("order-1")
+
+        assertTrue(scheduled)
+        verify(exactly = 1) { scheduler.scheduleReminder("order-1", "15/08/2026") }
+    }
+
+    @Test
+    fun `schedules nothing when no order is saved locally`() = runTest {
+        coEvery { preferences.orderFlow } returns flowOf(null)
+
+        val scheduled = ScheduleOrderReminderUseCase(preferences, scheduler).invoke("order-1")
+
+        assertFalse(scheduled)
+        verify(exactly = 0) { scheduler.scheduleReminder(any(), any()) }
+    }
+
+    @Test
+    fun `schedules nothing when the saved order is a leftover from another checkout`() = runTest {
+        // Guards against reminding the customer about a stale order still sitting in the
+        // local datastore instead of the one that was actually just paid.
+        coEvery { preferences.orderFlow } returns flowOf(order(id = "order-previous"))
+
+        val scheduled = ScheduleOrderReminderUseCase(preferences, scheduler).invoke("order-1")
+
+        assertFalse(scheduled)
+        verify(exactly = 0) { scheduler.scheduleReminder(any(), any()) }
+    }
+
+    @Test
+    fun `schedules nothing when the order carries no delivery date`() = runTest {
+        coEvery { preferences.orderFlow } returns flowOf(order(deliveryDate = ""))
+
+        val scheduled = ScheduleOrderReminderUseCase(preferences, scheduler).invoke("order-1")
+
+        assertFalse(scheduled)
+        verify(exactly = 0) { scheduler.scheduleReminder(any(), any()) }
+    }
+
+    @Test
+    fun `cancel delegates to the scheduler`() {
+        CancelOrderReminderUseCase(scheduler).invoke("order-1")
+
+        verify(exactly = 1) { scheduler.cancelReminder("order-1") }
+    }
+}

--- a/checkout/presentation/src/main/java/com/mtdevelopment/checkout/presentation/viewmodel/CheckoutViewModel.kt
+++ b/checkout/presentation/src/main/java/com/mtdevelopment/checkout/presentation/viewmodel/CheckoutViewModel.kt
@@ -31,6 +31,7 @@ import com.mtdevelopment.checkout.domain.usecase.ResetCheckoutStatusUseCase
 import com.mtdevelopment.checkout.domain.usecase.SaveCheckoutReferenceUseCase
 import com.mtdevelopment.checkout.domain.usecase.SaveCreatedCheckoutUseCase
 import com.mtdevelopment.checkout.domain.usecase.SavePaymentStateUseCase
+import com.mtdevelopment.checkout.domain.usecase.ScheduleOrderReminderUseCase
 import com.mtdevelopment.checkout.domain.usecase.SchedulePaymentFinalizationUseCase
 import com.mtdevelopment.checkout.domain.usecase.UpdateOrderStatus
 import com.mtdevelopment.checkout.domain.usecase.VerifyHostedCheckoutStatusUseCase
@@ -99,6 +100,7 @@ class CheckoutViewModel(
     private val getSavedOrderUseCase: GetSavedOrderUseCase,
     private val schedulePaymentFinalizationUseCase: SchedulePaymentFinalizationUseCase,
     private val clearPendingPaymentFinalizationUseCase: ClearPendingPaymentFinalizationUseCase,
+    private val scheduleOrderReminderUseCase: ScheduleOrderReminderUseCase,
     private val getSumUpPaymentLinkUseCase: GetSumUpPaymentLinkUseCase,
     private val verifyHostedCheckoutStatusUseCase: VerifyHostedCheckoutStatusUseCase
 ) : ViewModel(), KoinComponent {
@@ -423,11 +425,16 @@ class CheckoutViewModel(
      */
     fun resetAppStateAfterSuccess() {
         viewModelScope.launch {
+            val orderId = getSavedOrderUseCase.invoke().first().id
             // Update order status to PAID in Firestore
             updateOrderStatus.invoke(
-                orderId = getSavedOrderUseCase.invoke().first().id,
+                orderId = orderId,
                 newStatus = OrderStatus.PAID
             )
+            // The order is paid and will happen: remind the customer on the day.
+            // Idempotent with the same call in FinalizePaymentWorker — whichever path
+            // finalizes first schedules, the other replaces the identical reminder.
+            scheduleOrderReminderUseCase.invoke(orderId)
             // Empty the cart
             clearCartUseCase.invoke()
             // The order reached its terminal state in-app: the background

--- a/checkout/presentation/src/test/java/com/mtdevelopment/checkout/presentation/viewmodel/CheckoutViewModelTest.kt
+++ b/checkout/presentation/src/test/java/com/mtdevelopment/checkout/presentation/viewmodel/CheckoutViewModelTest.kt
@@ -23,6 +23,7 @@ import com.mtdevelopment.checkout.domain.usecase.ResetCheckoutStatusUseCase
 import com.mtdevelopment.checkout.domain.usecase.SaveCheckoutReferenceUseCase
 import com.mtdevelopment.checkout.domain.usecase.SaveCreatedCheckoutUseCase
 import com.mtdevelopment.checkout.domain.usecase.SavePaymentStateUseCase
+import com.mtdevelopment.checkout.domain.usecase.ScheduleOrderReminderUseCase
 import com.mtdevelopment.checkout.domain.usecase.SchedulePaymentFinalizationUseCase
 import com.mtdevelopment.checkout.domain.usecase.UpdateOrderStatus
 import com.mtdevelopment.checkout.domain.usecase.VerifyHostedCheckoutStatusUseCase
@@ -88,6 +89,7 @@ class CheckoutViewModelTest {
         mockk(relaxed = true)
     private val clearPendingPaymentFinalizationUseCase: ClearPendingPaymentFinalizationUseCase =
         mockk(relaxed = true)
+    private val scheduleOrderReminderUseCase: ScheduleOrderReminderUseCase = mockk(relaxed = true)
     private val getSumUpPaymentLinkUseCase: GetSumUpPaymentLinkUseCase = mockk()
     private val verifyHostedCheckoutStatusUseCase: VerifyHostedCheckoutStatusUseCase = mockk()
 
@@ -135,6 +137,7 @@ class CheckoutViewModelTest {
         getSavedOrderUseCase,
         schedulePaymentFinalizationUseCase,
         clearPendingPaymentFinalizationUseCase,
+        scheduleOrderReminderUseCase,
         getSumUpPaymentLinkUseCase,
         verifyHostedCheckoutStatusUseCase
     )
@@ -382,10 +385,11 @@ class CheckoutViewModelTest {
             val state = viewModel.paymentScreenState.value
             assertFalse(state.isLoading)
             assertNull(state.error)
-            // The PAID branch ran: order marked PAID and cart cleared.
+            // The PAID branch ran: order marked PAID, reminder scheduled, cart cleared.
             coVerify(exactly = 1) {
                 updateOrderStatus.invoke(orderId = "order-1", newStatus = OrderStatus.PAID)
             }
+            coVerify(exactly = 1) { scheduleOrderReminderUseCase.invoke("order-1") }
             coVerify(exactly = 1) { clearCartUseCase.invoke() }
         }
 

--- a/docs/spec-retrait-click-and-collect.md
+++ b/docs/spec-retrait-click-and-collect.md
@@ -1,0 +1,382 @@
+# Spec — Retrait en boutique (click & collect) et dates de marché
+
+**Statut :** spécification arrêtée, en attente des décisions ouvertes du §11.
+**Date :** 09/08/2026 · **Branche :** `claude/click-collect-market-dates-ef4279`
+**Prérequis de lecture :** `fromagerie-firestore-data-model`, `fromagerie-delivery-logistics-reference`,
+`fromagerie-change-control`.
+
+---
+
+## 1. Objet
+
+Permettre au client de commander sans se faire livrer, en venant chercher sa commande :
+
+- **à la fromagerie**, un jour d'ouverture (click & collect) ;
+- **sur un marché**, à une date et une adresse définies par l'admin.
+
+La livraison à domicile existante n'est pas modifiée dans son fonctionnement.
+
+### Dans le périmètre v1
+
+Les trois modes de retrait ; le paiement en ligne **ou** sur place ; la tarification différenciée
+par mode ; la gestion des jours de fermeture ; les rappels le jour J (retrait **et** livraison) ;
+les adaptations admin indispensables à la sécurité opérationnelle.
+
+### Hors périmètre v1
+
+Plafond de capacité par date (fermeture manuelle uniquement) ; créneaux horaires réservables
+(la plage est affichée, pas réservée) ; marchés récurrents (chaque date est saisie séparément) ;
+facture pour les paiements encaissés sur place ; toute modification de la chaîne de paiement en
+ligne.
+
+---
+
+## 2. Vocabulaire
+
+| Terme | Sens dans ce document |
+|---|---|
+| **Mode** | `LIVRAISON`, `RETRAIT_BOUTIQUE` ou `RETRAIT_MARCHE`. Porté par la commande. |
+| **Point de retrait** | La boutique (récurrente) ou une date de marché (ponctuelle). |
+| **Tournée / parcours** | Le `delivery_path` existant. Inchangé, et sans lien avec les points de retrait. |
+| **Instantané** | Copie du libellé/adresse/horaire du point, figée sur la commande à sa création. |
+
+---
+
+## 3. Parcours client
+
+### 3.1 Choix du mode
+
+Le mode est un **contexte global**, sélectionnable depuis le catalogue via un sélecteur dans la
+barre supérieure, et non une étape bloquante en début de parcours. Il vaut `LIVRAISON` par défaut,
+est persisté dans `SharedDatastore` (à côté de `lastSelectedPath`) et reste modifiable jusqu'à
+l'écran de paiement.
+
+Deuxième point d'entrée, au moins aussi important : lorsqu'une adresse se révèle **non éligible**
+(`NOT_ELIGIBLE`, `ASK_FOR_SUPPORT`, `STREET_NOT_COVERED`), le client tombe aujourd'hui sur un
+cul-de-sac avec un mail au support. Le retrait doit y être proposé comme rattrapage explicite.
+
+### 3.2 Écran de retrait
+
+En mode retrait, l'écran de livraison actuel est réduit :
+
+- **pas de champ adresse**, pas de géocodage, pas de calcul d'éligibilité, pas de tournée ;
+- champs demandés : **nom, email, téléphone** (le téléphone remplace fonctionnellement l'adresse :
+  c'est ce qui sert en cas de retard ou d'absence) ;
+- la carte affiche **un point** (boutique ou marché) au lieu du tracé de tournée ;
+- la liste de dates provient du point de retrait, pas de `BuildSelectableDeliveryDatesUseCase` ;
+- la **plage horaire** du point est affichée en clair sous la date choisie (ex. « samedi 8h–13h »).
+
+### 3.3 Dates proposées
+
+- **Boutique** : jours d'ouverture récurrents, moins les dates de fermeture (§5.2), moins les
+  dates déjà closes par la règle de clôture.
+- **Marché** : uniquement les dates saisies par l'admin, à venir et non closes.
+- **Clôture : J-1 à 12h00 pour tous les modes**, identique à la livraison actuelle. Aucune
+  divergence de règle entre modes en v1.
+
+### 3.4 Paiement
+
+Le client choisit entre **payer en ligne** (Google Pay → SumUp, chaîne strictement inchangée) et
+**payer sur place** au moment du retrait. Le mode de paiement est indépendant du mode de retrait.
+
+---
+
+## 4. Tarification par mode
+
+### 4.1 Le problème
+
+**Deux grilles tarifaires seulement** : le tarif livraison, qui s'applique aussi au marché, et le
+tarif boutique, légèrement inférieur. Le panier est néanmoins rempli **avant** que le mode ne soit
+connu, et `CartItem` fige le prix unitaire à l'ajout
+([CartItem.kt](../core/domain/src/main/java/com/mtdevelopment/core/model/CartItem.kt),
+total recalculé en `sum(price × quantity)` dans
+[CartViewModel.kt:150](../cart/presentation/src/main/java/com/mtdevelopment/cart/presentation/viewmodel/CartViewModel.kt:150)).
+
+Propriété structurante : **le tarif boutique est toujours ≤ au tarif livraison**. Le total ne peut
+donc jamais augmenter au changement de mode, quel que soit le chemin emprunté. Aucune garde
+« avertir d'une hausse » n'est nécessaire, et il ne faut pas en écrire une « au cas où » : elle
+serait du code mort masquant l'invariant.
+
+### 4.2 Options écartées
+
+**Demander le mode avant le catalogue.** Logique simple, aucun recalcul — mais un mur au premier
+lancement, avant même que le client ait vu un fromage. Écarté : la friction est placée au pire
+endroit possible.
+
+**Remise globale uniforme** (pourcentage ou montant fixe appliqué au panier). Saisie admin
+minimale, mais la baisse n'est pas uniforme d'un produit à l'autre. Un pourcentage imposerait de
+surcroît une règle d'arrondi sur des montants en centimes, terrain sur lequel le projet a déjà
+produit des bugs monétaires.
+
+### 4.3 Solution retenue
+
+Un **prix boutique facultatif par produit**, avec le mode comme contexte global visible :
+
+1. Le catalogue affiche les prix du mode actif, mis à jour immédiatement au changement de mode.
+2. **La livraison est la référence affichée par défaut** ; le mode marché utilise exactement les
+   mêmes prix.
+3. En mode boutique, l'écart est mis en avant comme un gain (prix livraison barré ou badge
+   « −0,40 € »). Une baisse est un argument de conversion : elle doit se voir.
+4. Un produit sans prix boutique renseigné est vendu au prix livraison, sans mention d'écart.
+5. À l'écran de retrait comme au récapitulatif, une ligne explicite le tarif appliqué
+   (ex. « Tarifs retrait boutique »).
+
+**Règle invariante : le total ne doit jamais augmenter entre ce que le client a vu et ce qu'il
+paie.** Ici elle est garantie par construction, pas par une vérification à l'exécution.
+
+### 4.4 Conséquence technique
+
+Le changement de mode déclenche une **re-tarification du panier** : chaque `CartItem` est rapproché
+du catalogue **par son nom** et son `price` réécrit. Si un produit du panier n'est plus au
+catalogue, sa ligne conserve son prix figé et le fait est signalé plutôt que masqué.
+
+---
+
+## 5. Modèle de données
+
+> L'application est **en production** : toute évolution est **strictement additive**. Les anciens
+> APK client continueront d'écrire des commandes sans les nouveaux champs — le défaut à la lecture
+> n'est pas une phase transitoire, il est permanent.
+
+### 5.1 `orders` — champs ajoutés
+
+Convention de la collection : **snake_case**.
+
+| Champ | Type | Défaut à la lecture | Rôle |
+|---|---|---|---|
+| `fulfillment_type` | String | `DELIVERY` | `DELIVERY` / `PICKUP_SHOP` / `PICKUP_MARKET` |
+| `payment_mode` | String | `ONLINE` | `ONLINE` / `ON_SITE` |
+| `customer_phone` | String? | `null` | Contact retrait |
+| `pickup_point_id` | String? | `null` | Référence au point de retrait |
+| `pickup_label` | String? | `null` | **Instantané** — ex. « Marché de Pontarlier » |
+| `pickup_address` | String? | `null` | **Instantané** |
+| `pickup_time_range` | String? | `null` | **Instantané** — ex. « 8h–13h » |
+
+Les trois derniers champs sont **recopiés** sur la commande, pas seulement référencés : `orders`
+est le registre historique et ne doit dépendre d'aucune donnée mutable. Sans cela, corriger ou
+supprimer une date de marché réécrirait les commandes passées.
+
+`customer_address` reste requis par le schéma : en mode retrait il est renseigné avec l'adresse de
+facturation retournée par Google Pay, ou vide pour un paiement sur place.
+
+### 5.2 `pickup_points` — nouvelle collection
+
+| Champ | Type | Notes |
+|---|---|---|
+| `type` | String | `SHOP` / `MARKET` |
+| `label` | String | Nom affiché au client |
+| `address` | String | Adresse postale ; géocodée pour le pin carte |
+| `latitude` / `longitude` | Double | Résultat du géocodage (réutilise l'API Géoplateforme) |
+| `time_range` | String | Plage horaire affichée, non réservable (ex. « 8h–13h ») |
+| `opening_days` | List\<String\> | **`SHOP` uniquement** — noms `DayOfWeek` |
+| `closed_dates` | List\<String\> | **`SHOP` uniquement** — `dd/MM/yyyy`, vacances et fermetures |
+| `date` | String? | **`MARKET` uniquement** — `dd/MM/yyyy`, date unique |
+
+Un unique document `SHOP` est attendu ; N documents `MARKET`, un par date. Aucun marché n'est
+récurrent en v1 : les marchés reviennent environ une fois par mois, sans régularité hebdomadaire
+exploitable, donc chaque date est saisie individuellement.
+
+**Fermetures** : côté boutique via `closed_dates` ; côté marché en supprimant la date.
+
+### 5.3 `products` — champs ajoutés
+
+Convention de la collection : **camelCase** (`priceCents`, `imgUrl`) — différente de `orders`,
+respecter chacune.
+
+| Champ | Type | Défaut | Rôle |
+|---|---|---|---|
+| `priceCentsPickupShop` | Long? | retombe sur `priceCents` | Tarif retrait boutique |
+
+`priceCents` reste le **tarif livraison et la référence**, et sert tel quel au mode marché : aucun
+champ de prix marché n'existe. Le prix boutique est facultatif produit par produit — l'admin ne
+renseigne que ce qui diffère réellement. La branche de lecture des anciennes clés courtes
+(`b`..`h`) n'a pas d'équivalent et retombe naturellement sur `priceCents`.
+
+**Contrainte de saisie :** un prix boutique supérieur au prix livraison doit être refusé à
+l'édition. C'est ce qui maintient l'invariant du §4.1 à la source, plutôt que de le rattraper côté
+client.
+
+### 5.4 `database_update` — troisième document
+
+Ajout de `pickup_timestamp`, sur le même modèle que `products_timestamp` et `path_timestamp`.
+**Toute écriture sur `pickup_points` doit le mettre à jour**, sans quoi les clients servent
+indéfiniment un cache périmé.
+
+### 5.5 Room
+
+- `ProductEntity` : une colonne nullable ajoutée → **migration 6 → 7** additive
+  (`ALTER TABLE products ADD COLUMN priceCentsPickupShop INTEGER DEFAULT NULL`).
+- Points de retrait : nouvelle table `pickup_points` sur le même schéma que §5.2.
+
+⚠️ Les colonnes Room portent les **noms de propriétés Kotlin**, jamais les valeurs `@SerialName`.
+Écrire une migration contre le mauvais nom produit une colonne fantôme.
+
+⚠️ **Une lecture Firestore hors-ligne réussit et renvoie zéro document** : `addOnFailureListener`
+ne se déclenche pas. « Zéro point de retrait » doit être traité comme un **échec**, jamais comme
+une réponse valide — c'est le piège qui avait rendu toutes les adresses non livrables au premier
+lancement sans réseau (corrigé le 29/07 sur les parcours).
+
+---
+
+## 6. Paiement et cycle de vie
+
+### 6.1 États
+
+| Situation | `status` | `payment_mode` |
+|---|---|---|
+| Commande créée, paiement en ligne en cours | `PENDING` | `ONLINE` |
+| Paiement en ligne réussi | `PAID` | `ONLINE` |
+| Paiement en ligne échoué | `CANCELED` | `ONLINE` |
+| Commande à payer sur place | `PENDING` | `ON_SITE` |
+| Encaissée par l'admin au retrait | `PAID` | `ON_SITE` |
+
+Le champ `payment_mode` est ce qui **désambiguïse `PENDING`**, aujourd'hui porteur de deux sens
+incompatibles : « paiement en vol » et « à payer sur place ». On n'ajoute **pas** de valeur à
+`OrderStatus` pour cela : le lecteur admin fait `runCatching { valueOf(…) }.getOrDefault(PENDING)`,
+donc un ancien APK afficherait un nouveau statut comme `PENDING` — silencieusement, et on
+retomberait dans la confusion qu'on cherche à lever. Un champ inconnu, lui, est simplement ignoré.
+
+### 6.2 Encaissement sur place
+
+Action admin « Encaissé » sur la commande → passage en `PAID`. **Aucune facture n'est émise** pour
+ce chemin : le flux Invoice Ninja reste réservé aux paiements en ligne.
+
+### 6.3 Annulation automatique des commandes non retirées
+
+Une commande **`payment_mode = ON_SITE` et `status = PENDING`** dont la date de retrait est
+dépassée de **plus de 3 jours** passe automatiquement en `CANCELED`.
+
+⚠️ **Cette règle ne doit jamais s'appliquer à une commande `ONLINE`.** Une commande en ligne
+bloquée en `PENDING` signale un paiement en vol ou une finalisation en échec : elle demande une
+investigation, pas une annulation silencieuse qui effacerait la trace d'un client potentiellement
+débité.
+
+Implémentation privilégiée : **Cloud Function planifiée** (elle s'exécute sans que personne
+n'ouvre l'app). Repli acceptable si l'on veut éviter le coût backend : un balayage côté app admin
+au chargement de la liste des commandes — au prix d'une exécution qui dépend de l'ouverture de
+l'app.
+
+---
+
+## 7. Rappels et notifications
+
+L'infrastructure existe déjà et n'est pas à construire : `ClientMessagingService`,
+`NotificationLocalStore` (centre de notifications in-app), canal `fromagerie_client_general`,
+demande de `POST_NOTIFICATIONS` dans `MainActivity`.
+
+Elle ne convient toutefois **pas** au besoin : le ciblage est **par topic** (`clients`, tout le
+monde), sans registre de tokens — `onNewToken` n'envoie rien. Un rappel nominatif ne peut pas
+passer par ce canal.
+
+**Solution : rappel local planifié.** La date est connue au moment de la commande, sur l'appareil
+qui l'a passée. Au checkout, un `OneTimeWorkRequest` unique par commande est planifié pour le matin
+du jour J ; à son déclenchement il poste la notification système **et** écrit dans
+`NotificationLocalStore` pour que le centre in-app reflète la même chose.
+
+- Vaut pour **tous les modes**, retrait comme livraison.
+- `WorkManager` survit au redémarrage, contrairement à un `AlarmManager` qui exigerait la
+  permission d'alarme exacte depuis Android 12.
+- Le travail est annulé par nom unique si la commande est annulée.
+- Précision de l'ordre de l'heure, pas de la minute : suffisant pour un rappel « aujourd'hui ».
+- Le refus de `POST_NOTIFICATIONS` reste respecté : la notification n'apparaît qu'in-app.
+
+**Ce lot est autonome** : il ne dépend pas du click & collect et peut être livré avant.
+
+---
+
+## 8. Parcours admin
+
+### 8.1 Gestion des points de retrait
+
+Nouvel écran CRUD, calqué sur `PathEditScreen` (brouillon `rememberSaveable` type `PathDraft`) :
+horaires et jours d'ouverture de la boutique, dates de fermeture, création/édition/suppression des
+dates de marché avec adresse géocodée. Entrée à ajouter dans la navigation admin.
+
+### 8.2 Commandes
+
+Actions « Encaissé » (→ `PAID`) et « Retiré » (→ `DELIVERED`) sur les commandes en retrait.
+
+### 8.3 Trois impacts existants à traiter — dont un bloquant
+
+**Tournée du jour — correction obligatoire.**
+[DeliveryHelperScreen.kt:218](../admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/screen/DeliveryHelperScreen.kt:218)
+prend **toutes** les commandes du jour et envoie leurs `customerAddress` à l'optimisation Google
+Routes, puis au service de tracking. Sans filtre sur `fulfillment_type == DELIVERY`, une commande à
+retirer devient un arrêt de livraison à domicile. Ce n'est pas une amélioration, c'est une
+condition de non-régression.
+
+**Préparation.** `OrderPreparationScreen` agrège par date seule : une journée mêlant tournée,
+retraits boutique et marché produirait un unique « 4 Comté » sans distinguer ce qui part dans le
+camion. Le regroupement devient **(date × point de retrait)**, et l'identifiant composite de
+`preparation_status` (`"05072026_ComtéAOP"`) doit intégrer le point sous peine de collision entre
+deux lots du même jour.
+
+**Commandes manuelles.** `DeliveryAddDialog` crée aussi des commandes : elles doivent porter
+`fulfillment_type = DELIVERY` explicitement.
+
+---
+
+## 9. Découpage en lots
+
+| Lot | Contenu | Livrable indépendamment |
+|---|---|---|
+| **0** | Rappels jour J (§7), livraison comprise | **Oui** |
+| **1** | Champs `orders` + filtre tournée + regroupement préparation | Oui (invisible côté client) |
+| **2** | Collection `pickup_points` + écran admin de gestion | Oui |
+| **3** | Parcours client de retrait (sélecteur, formulaire, dates, carte) | Non — dépend de 1 et 2 |
+| **4** | Tarification par mode (§4) | Non — dépend de 3 |
+| **5** | Paiement sur place + encaissement + annulation J+3 | Non — dépend de 3 |
+
+L'ordre 1 → 2 → 3 garantit qu'à aucun moment une commande en retrait ne peut exister sans que
+l'admin sache la distinguer d'une livraison.
+
+---
+
+## 10. Critères d'acceptation
+
+1. Une commande écrite par un APK antérieur, sans `fulfillment_type`, est lue et traitée comme une
+   livraison — de façon permanente, pas transitoire.
+2. Une commande en retrait n'apparaît **jamais** dans l'optimisation de tournée ni dans le service
+   de suivi de livraison.
+3. Une journée mêlant tournée + retrait boutique + marché produit **trois lots de préparation
+   distincts**, sans collision d'identifiants dans `preparation_status`.
+4. Le total affiché au client ne peut jamais augmenter entre le panier et le paiement, quel que
+   soit l'enchaînement de changements de mode ; en mode boutique, l'économie réalisée est visible
+   sur les produits concernés.
+5. Une date de fermeture boutique fait disparaître le jour correspondant des dates proposées.
+6. Modifier ou supprimer un point de retrait ne modifie aucune commande existante.
+7. Une commande `ON_SITE` non retirée passe en `CANCELED` à J+3 ; une commande `ONLINE` en
+   `PENDING` n'est **jamais** annulée automatiquement.
+8. Sans réseau au premier lancement, l'absence de points de retrait est signalée comme une erreur,
+   jamais présentée comme « aucun retrait possible ».
+9. Le rappel jour J se déclenche pour une commande en livraison comme pour une commande en retrait,
+   et survit à un redémarrage de l'appareil.
+10. Les deux flavors compilent, et la suite de tests ne régresse pas au-delà des 2 échecs connus
+    d'`AdminViewModelTest`.
+
+---
+
+## 11. Décisions encore ouvertes
+
+1. **Annulation J+3 : Cloud Function planifiée ou balayage côté app admin ?** (§6.3)
+2. **Fermer une date sur laquelle des commandes existent déjà** — refuser, ou avertir et laisser
+   faire en listant les clients à prévenir ?
+3. **Adresse de facturation en retrait avec paiement sur place** — aucune adresse n'est alors
+   collectée. Acceptable puisqu'aucune facture n'est émise, à confirmer.
+
+Aucune de ces trois questions ne bloque le démarrage : les lots 0 à 4 peuvent être menés sans y
+répondre, seul le lot 5 attend la réponse à la n°1.
+
+---
+
+## 12. Contraintes projet
+
+- **Changement de schéma Firestore** → classe (e) au sens de `fromagerie-change-control` :
+  validation explicite de Tommy avant merge.
+- **Additif uniquement** : aucun renommage, aucune suppression, aucun changement de type ou de
+  sémantique d'un champ existant.
+- **Aucune écriture sur la Firestore de production** depuis une session de dev. Les mappings se
+  prouvent par tests unitaires sur les DTO.
+- **La chaîne de paiement en ligne n'est pas touchée** — choix délibéré : le paiement sur place est
+  un chemin parallèle, pas une modification du chemin existant.
+- Les deux flavors doivent compiler ; livraison par branche → PR vers `main`.


### PR DESCRIPTION
Two commits: the specification for the whole click & collect / market-dates feature, and its first lot — which stands alone and ships value to the delivery flow that exists today.

## Lot 0 — remind the customer the morning their order is due

Applies to **every order**, delivery included. Nothing here depends on click & collect.

**Local, not pushed.** The client FCM targeting is topic-based (every device listens to `clients`, `onNewToken` uploads nothing), so a per-customer reminder cannot travel through it. The delivery date is known at checkout, on the very device that placed the order — so a `WorkManager` job is enqueued for 8am on the delivery day. WorkManager survives a reboot; an `AlarmManager` would need the exact-alarm permission Android 12 introduced. No network constraint: the reminder carries no server data and must fire with no signal.

**Scheduled on both paths that reach PAID** — the in-app flow and `FinalizePaymentWorker` — so a payment that completes while the app is dead still produces a reminder. The worker cancels it on FAILED. Keyed per order with `ExistingWorkPolicy.REPLACE`, so the two paths racing cannot produce two reminders.

**Never scheduled at order creation**: an order that is never paid must not remind anyone, and abandonment leaves no event to cancel one.

### Two traps this deliberately avoids

- `ScheduleOrderReminderUseCase` only trusts the locally saved order when its id matches the one just finalized — otherwise a leftover from a previous checkout gets reminded about.
- The scheduler binding is flavor-specific, and **the admin flavor gets a real no-op implementation**. Admin reaches the checkout screen too, and Koin resolves at runtime: an unbound definition would not fail the build, it would crash the shop owner's app the first time he opened checkout.

`ClientNotifier` extracts the notification-posting block `ClientMessagingService` already had, so pushes and reminders share one channel, icon and tap target instead of drifting apart.

## Spec

`docs/spec-retrait-click-and-collect.md` records the decisions made with the owner on 09/08/2026 and the constraints the current model imposes — most importantly that orders carry no fulfillment mode today, which is why the delivery-day route would otherwise load a click & collect order into the van. Six lots, ordered so no pickup order can exist before the admin side can tell it apart from a delivery.

**Nothing in this PR changes the Firestore schema or the payment chain.** The schema work starts at lot 1 and needs explicit sign-off.

## Verification

- Both flavors compile (`compileClientDebugKotlin`, `compileAdminDebugKotlin`).
- 11 new unit tests: the 8am rule (past dates, same-day before and after the hour, unparseable input) and the use cases (stale saved order, missing date, cancel).
- Full suite at the documented baseline — the same 2 `AdminViewModelTest` failures, no new ones.
- **Not verified on device**: the trigger sits behind a completed payment, and this project never completes a real one. The DI wiring is the residual runtime risk; a launch of the client debug build on a real device would close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)