### PR TITLE
Lot 1 — record how an order is fulfilled, and keep pickups out of the van

### DIFF
--- a/admin/data/src/main/java/com/mtdevelopment/admin/data/source/FirestoreAdminDatasource.kt
+++ b/admin/data/src/main/java/com/mtdevelopment/admin/data/source/FirestoreAdminDatasource.kt
@@ -6,8 +6,10 @@ import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.firestore
 import com.mtdevelopment.admin.data.model.DataDeliveryPath
+import com.mtdevelopment.core.model.FulfillmentType
 import com.mtdevelopment.core.model.OrderData
 import com.mtdevelopment.core.model.OrderStatus
+import com.mtdevelopment.core.model.PaymentMode
 import com.mtdevelopment.core.model.PreparationStatusData
 import com.mtdevelopment.core.model.ProductData
 import kotlinx.coroutines.tasks.await
@@ -201,7 +203,21 @@ class FirestoreAdminDatasource(
                             }.getOrDefault(OrderStatus.PENDING),
                             note = item.data?.get("note") as? String,
                             billing_address = item.data?.get("billing_address").toString(),
-                            is_manually_added = item.data?.get("is_manually_added") as? Boolean
+                            is_manually_added = item.data?.get("is_manually_added") as? Boolean,
+                            // Absent on every order written before these fields existed,
+                            // and on those still written by older app versions: both
+                            // conversions fall back rather than skip the document.
+                            fulfillment_type = FulfillmentType.fromStoredValue(
+                                item.data?.get("fulfillment_type") as? String
+                            ),
+                            payment_mode = PaymentMode.fromStoredValue(
+                                item.data?.get("payment_mode") as? String
+                            ),
+                            customer_phone = item.data?.get("customer_phone") as? String,
+                            pickup_point_id = item.data?.get("pickup_point_id") as? String,
+                            pickup_label = item.data?.get("pickup_label") as? String,
+                            pickup_address = item.data?.get("pickup_address") as? String,
+                            pickup_time_range = item.data?.get("pickup_time_range") as? String
                         )
                     })
                 } catch (e: Exception) {

--- a/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/screen/DeliveryHelperScreen.kt
+++ b/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/screen/DeliveryHelperScreen.kt
@@ -63,6 +63,7 @@ import com.mtdevelopment.core.domain.toStringDate
 import com.mtdevelopment.core.domain.toTimeStamp
 import com.mtdevelopment.core.model.Order
 import com.mtdevelopment.core.model.OrderStatus
+import com.mtdevelopment.core.model.deliveriesOnly
 import com.mtdevelopment.core.presentation.composable.ErrorOverlay
 import com.mtdevelopment.core.presentation.composable.RiveAnimation
 import com.mtdevelopment.core.util.koinViewModel
@@ -146,9 +147,15 @@ fun DeliveryHelperScreen(
     // State derivation: Filtering orders for today
     val todayDate = LocalDate.now().atStartOfDay(java.time.ZoneOffset.UTC)
 
-    val dailyOrders = remember(state.value) {
+    // Everything on this screen — the route optimizer, the maps link, the markers, the
+    // tracking service — reasons about stops the van has to drive to. Orders the customer
+    // collects have an address that must never become one, so they are dropped here, once,
+    // rather than at each of those consumers.
+    val routableOrders = remember(state.value.orders) { state.value.orders.deliveriesOnly() }
+
+    val dailyOrders = remember(routableOrders) {
         mutableStateOf(
-            state.value.orders.filter {
+            routableOrders.filter {
                 it.deliveryDate.toTimeStamp() == todayDate.toInstant().toEpochMilli()
             }
         )
@@ -163,9 +170,9 @@ fun DeliveryHelperScreen(
     }
 
     // Find the next upcoming delivery date if today is empty
-    val nextOrderDate = remember(state.value.orders) {
-        if (state.value.orders.isNotEmpty()) {
-            val filteredValue = state.value.orders.filter {
+    val nextOrderDate = remember(routableOrders) {
+        if (routableOrders.isNotEmpty()) {
+            val filteredValue = routableOrders.filter {
                 it.deliveryDate.toTimeStamp() > todayDate.toInstant().toEpochMilli()
             }
             if (filteredValue.isNotEmpty()) {
@@ -178,9 +185,9 @@ fun DeliveryHelperScreen(
         }
     }
 
-    val subtitleText = remember(dailyOrders.value, state.value.orders) {
+    val subtitleText = remember(dailyOrders.value, routableOrders) {
         if (dailyOrders.value.isEmpty()) {
-            if (state.value.orders.isNotEmpty() && nextOrderDate != null
+            if (routableOrders.isNotEmpty() && nextOrderDate != null
             ) {
                 "Prochaine livraison le ${
                     nextOrderDate.deliveryDate

--- a/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/screen/OrderPreparationScreen.kt
+++ b/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/screen/OrderPreparationScreen.kt
@@ -48,7 +48,9 @@ import com.mtdevelopment.admin.presentation.viewmodel.AdminViewModel
 import com.mtdevelopment.core.domain.toLocalDate
 import com.mtdevelopment.core.domain.toTimeStamp
 import com.mtdevelopment.core.model.Order
+import com.mtdevelopment.core.model.PreparationGroup
 import com.mtdevelopment.core.model.PreparationStatus
+import com.mtdevelopment.core.model.preparationGroup
 import com.mtdevelopment.core.presentation.composable.ErrorOverlay
 import com.mtdevelopment.core.presentation.composable.RiveAnimation
 import com.mtdevelopment.core.util.koinViewModel
@@ -100,10 +102,16 @@ fun OrderPreparationList(
     preparationStatuses: List<PreparationStatus>,
     onUpdateStatus: (PreparationStatus) -> Unit
 ) {
-    // Sort and unique delivery dates, newest first
-    val nextDeliveryDates =
-        orders.map { it.deliveryDate }.sortedByDescending { it.toTimeStamp() }.toSet()
-    val ordersByDeliveryDate = orders.groupBy { it.deliveryDate }
+    // Batches, newest first. Grouping on the date alone would merge a tournée, the shop
+    // pickups and a market of the same day into one aggregate, leaving no way to tell what
+    // goes in the van — hence the group, which also carries the pickup point so two
+    // markets on one day stay apart.
+    val ordersByGroup = orders.groupBy { it.preparationGroup }
+    val groups = ordersByGroup.keys.sortedWith(
+        compareByDescending<PreparationGroup> { it.deliveryDate.toTimeStamp() }
+            .thenBy { it.fulfillmentType }
+            .thenBy { it.pickupLabel.orEmpty() }
+    )
 
     // Captured once so every item of a frame compares against the same day and
     // scrolling does not re-evaluate the clock.
@@ -111,12 +119,13 @@ fun OrderPreparationList(
 
     LazyColumn {
 
-        for (deliveryDate in nextDeliveryDates) {
-            val ordersForDate = ordersByDeliveryDate[deliveryDate] ?: emptyList()
+        for (group in groups) {
+            val deliveryDate = group.deliveryDate
+            val ordersForDate = ordersByGroup[group] ?: emptyList()
             val isPastDate = deliveryDate.toLocalDate()?.isBefore(today) == true
             if (ordersForDate.isNotEmpty()) {
 
-                // Aggregate product quantities for the current delivery date.
+                // Aggregate product quantities for the current batch.
                 // e.g., if Order A has 2 Milk and Order B has 3 Milk, results in {Milk=5}
                 val quantityForProducts: Map<String, Int> =
                     ordersForDate.fold(mutableMapOf()) { accumulator, currentMap ->
@@ -139,18 +148,36 @@ fun OrderPreparationList(
                                 }
                             )
                     ) {
-                        Text(
+                        Column(
                             modifier = Modifier
                                 .padding(horizontal = 32.dp, vertical = 16.dp)
-                                .align(Alignment.CenterStart),
-                            text = deliveryDate,
-                            style = MaterialTheme.typography.titleLarge,
-                            color = if (isPastDate) {
-                                MaterialTheme.colorScheme.onSurfaceVariant
-                            } else {
-                                MaterialTheme.colorScheme.onSecondary
-                            }
-                        )
+                                .align(Alignment.CenterStart)
+                        ) {
+                            Text(
+                                text = deliveryDate,
+                                style = MaterialTheme.typography.titleLarge,
+                                color = if (isPastDate) {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                } else {
+                                    MaterialTheme.colorScheme.onSecondary
+                                }
+                            )
+                            // Deliveries keep a date-only header, exactly as before. Only a
+                            // pickup batch needs naming, because that is the only case where
+                            // one date carries several destinations.
+                            group.pickupLabel?.takeIf { group.fulfillmentType.isPickup }
+                                ?.let { label ->
+                                    Text(
+                                        text = label,
+                                        style = MaterialTheme.typography.titleSmall,
+                                        color = if (isPastDate) {
+                                            MaterialTheme.colorScheme.onSurfaceVariant
+                                        } else {
+                                            MaterialTheme.colorScheme.onSecondary
+                                        }
+                                    )
+                                }
+                        }
                     }
                 }
 
@@ -173,8 +200,8 @@ fun OrderPreparationList(
                         modifier = modifier,
                         product = item.first,
                         quantity = item.second,
-                        itemsPerClients = ordersByDeliveryDate[deliveryDate] ?: listOf(),
-                        deliveryDate = deliveryDate,
+                        itemsPerClients = ordersForDate,
+                        group = group,
                         isPastDate = isPastDate,
                         preparationStatuses = preparationStatuses,
                         onUpdateStatus = onUpdateStatus
@@ -196,7 +223,7 @@ fun OrderPreparationListItem(
     product: String,
     quantity: Int,
     itemsPerClients: List<Order>,
-    deliveryDate: String,
+    group: PreparationGroup,
     isPastDate: Boolean,
     preparationStatuses: List<PreparationStatus>,
     onUpdateStatus: (PreparationStatus) -> Unit
@@ -213,8 +240,9 @@ fun OrderPreparationListItem(
     }
 
     val showDetails = remember { mutableStateOf(false) }
-    // Generate a unique ID for the preparation status of this product on this date
-    val statusId = "${deliveryDate.replace("/", "")}_${product.replace(" ", "")}"
+    // Unique per (batch, product): deliveries keep the historical id so ticks already
+    // stored in Firestore keep matching, pickups get the point appended.
+    val statusId = group.statusIdFor(product)
     val isDone = preparationStatuses.find { it.id == statusId }?.isPrepared ?: false
 
     val rotation = animateFloatAsState(
@@ -263,7 +291,7 @@ fun OrderPreparationListItem(
                         onUpdateStatus(
                             PreparationStatus(
                                 id = statusId,
-                                date = deliveryDate,
+                                date = group.deliveryDate,
                                 productName = product,
                                 isPrepared = isChecked
                             )

--- a/app/src/admin/java/com/mtdevelopment/lafromagerie/DeliveryTrackingService.kt
+++ b/app/src/admin/java/com/mtdevelopment/lafromagerie/DeliveryTrackingService.kt
@@ -19,6 +19,7 @@ import com.mtdevelopment.admin.domain.usecase.SetIsInTrackingModeUseCase
 import com.mtdevelopment.admin.presentation.R.drawable
 import com.mtdevelopment.core.domain.toStringDate
 import com.mtdevelopment.core.model.Order
+import com.mtdevelopment.core.model.deliveriesOnly
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -89,7 +90,10 @@ class DeliveryTrackingService : Service(), KoinComponent {
                         LocalDate.now().atStartOfDay(java.time.ZoneOffset.UTC)
                             .toInstant().toEpochMilli().toStringDate()
 
-                    todaysOrders = allOrders.filter { it.deliveryDate == todayStr }
+                    // Pickup orders are dropped before anything reaches the route: their
+                    // customer address is a billing detail, never a stop to drive to.
+                    todaysOrders = allOrders.deliveriesOnly()
+                        .filter { it.deliveryDate == todayStr }
                     if (todaysOrders.isNotEmpty()) {
                         serviceScope.launch {
                             try {

--- a/core/data/src/main/java/com/mtdevelopment/core/model/OrderData.kt
+++ b/core/data/src/main/java/com/mtdevelopment/core/model/OrderData.kt
@@ -30,7 +30,27 @@ data class OrderData(
     @SerialName("is_manually_added")
     val is_manually_added: Boolean?,
     @SerialName("total_price")
-    val total_price: Long? = null
+    val total_price: Long? = null,
+    // Everything below is additive: the app is live, so orders written by older versions
+    // arrive without these keys and must map to the defaults rather than fail.
+    //
+    // Property names are snake_case on purpose. Firestore's `set` uses its own reflective
+    // POJO mapper, not kotlinx.serialization, so on the write path the Kotlin property
+    // name *is* the document key and @SerialName has no say in it.
+    @SerialName("fulfillment_type")
+    val fulfillment_type: FulfillmentType = FulfillmentType.DELIVERY,
+    @SerialName("payment_mode")
+    val payment_mode: PaymentMode = PaymentMode.ONLINE,
+    @SerialName("customer_phone")
+    val customer_phone: String? = null,
+    @SerialName("pickup_point_id")
+    val pickup_point_id: String? = null,
+    @SerialName("pickup_label")
+    val pickup_label: String? = null,
+    @SerialName("pickup_address")
+    val pickup_address: String? = null,
+    @SerialName("pickup_time_range")
+    val pickup_time_range: String? = null
 )
 
 fun OrderData.toOrder(): Order {
@@ -46,7 +66,14 @@ fun OrderData.toOrder(): Order {
         status = status,
         note = note,
         isManuallyAdded = is_manually_added,
-        totalPrice = total_price
+        totalPrice = total_price,
+        fulfillmentType = fulfillment_type,
+        paymentMode = payment_mode,
+        customerPhone = customer_phone,
+        pickupPointId = pickup_point_id,
+        pickupLabel = pickup_label,
+        pickupAddress = pickup_address,
+        pickupTimeRange = pickup_time_range
     )
 }
 
@@ -63,6 +90,13 @@ fun Order.toOrderData(): OrderData {
         status = status,
         note = note,
         is_manually_added = isManuallyAdded,
-        total_price = totalPrice
+        total_price = totalPrice,
+        fulfillment_type = fulfillmentType,
+        payment_mode = paymentMode,
+        customer_phone = customerPhone,
+        pickup_point_id = pickupPointId,
+        pickup_label = pickupLabel,
+        pickup_address = pickupAddress,
+        pickup_time_range = pickupTimeRange
     )
 }

--- a/core/data/src/test/java/com/mtdevelopment/core/model/OrderDataTest.kt
+++ b/core/data/src/test/java/com/mtdevelopment/core/model/OrderDataTest.kt
@@ -1,0 +1,95 @@
+package com.mtdevelopment.core.model
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class OrderDataTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun orderData() = OrderData(
+        id = "order-1",
+        customer_name = "Jean Dupont",
+        customer_address = "1 rue du Comté, 25300 Pontarlier",
+        billing_address = "1 rue du Comté, 25300 Pontarlier",
+        delivery_date = "05/07/2026",
+        order_date = "01/07/2026",
+        products = mapOf("Comté AOP" to 2),
+        status = OrderStatus.PAID,
+        note = null,
+        is_manually_added = false
+    )
+
+    @Test
+    fun `a document without the pickup fields decodes as a paid-online delivery`() {
+        // The shape every order written before this change has, and the one older app
+        // versions keep writing. It must decode, not blow up on missing keys.
+        val stored = """
+            {
+              "id": "order-1",
+              "customer_name": "Jean Dupont",
+              "customer_address": "1 rue du Comté",
+              "billing_address": "1 rue du Comté",
+              "delivery_date": "05/07/2026",
+              "order_date": "01/07/2026",
+              "products": { "Comté AOP": 2 },
+              "status": "PAID",
+              "note": null,
+              "is_manually_added": false
+            }
+        """.trimIndent()
+
+        val decoded = json.decodeFromString<OrderData>(stored)
+
+        assertEquals(FulfillmentType.DELIVERY, decoded.fulfillment_type)
+        assertEquals(PaymentMode.ONLINE, decoded.payment_mode)
+        assertNull(decoded.customer_phone)
+        assertNull(decoded.pickup_point_id)
+        assertNull(decoded.pickup_label)
+        assertNull(decoded.pickup_address)
+        assertNull(decoded.pickup_time_range)
+    }
+
+    @Test
+    fun `a pickup order round-trips through the domain model`() {
+        val data = orderData().copy(
+            fulfillment_type = FulfillmentType.PICKUP_MARKET,
+            payment_mode = PaymentMode.ON_SITE,
+            customer_phone = "0601020304",
+            pickup_point_id = "market-pontarlier-0507",
+            pickup_label = "Marché de Pontarlier",
+            pickup_address = "Place Saint-Bénigne, 25300 Pontarlier",
+            pickup_time_range = "8h-13h"
+        )
+
+        val restored = data.toOrder().toOrderData()
+
+        assertEquals(data, restored)
+    }
+
+    @Test
+    fun `the domain mapping carries the pickup snapshot both ways`() {
+        val order = orderData().copy(
+            fulfillment_type = FulfillmentType.PICKUP_SHOP,
+            pickup_point_id = "shop",
+            pickup_label = "La Fromagerie",
+            pickup_address = "3 Grande Rue, 25300 Pontarlier",
+            pickup_time_range = "9h-12h / 15h-19h"
+        ).toOrder()
+
+        assertEquals(FulfillmentType.PICKUP_SHOP, order.fulfillmentType)
+        assertEquals("shop", order.pickupPointId)
+        assertEquals("La Fromagerie", order.pickupLabel)
+        assertEquals("3 Grande Rue, 25300 Pontarlier", order.pickupAddress)
+        assertEquals("9h-12h / 15h-19h", order.pickupTimeRange)
+    }
+
+    @Test
+    fun `a delivery order still round-trips unchanged`() {
+        val data = orderData()
+
+        assertEquals(data, data.toOrder().toOrderData())
+    }
+}

--- a/core/domain/src/main/java/com/mtdevelopment/core/model/FulfillmentType.kt
+++ b/core/domain/src/main/java/com/mtdevelopment/core/model/FulfillmentType.kt
@@ -1,0 +1,38 @@
+package com.mtdevelopment.core.model
+
+/**
+ * How the customer takes delivery of an order.
+ *
+ * Until this field existed, an order recorded only its delivery date and the tournée was
+ * inferred from it. That inference breaks the moment a pickup and a delivery can fall on
+ * the same day, which is why the mode is now recorded explicitly — most importantly so the
+ * delivery-day route never loads a pickup order into the van.
+ *
+ * [DELIVERY] is the default everywhere: orders written before this field existed, and by
+ * app versions that still do not know about it, carry no value and must read as deliveries
+ * permanently — not just during a migration window.
+ */
+enum class FulfillmentType {
+    /** Driven to the customer's address on a tournée. */
+    DELIVERY,
+
+    /** Collected by the customer at the shop. */
+    PICKUP_SHOP,
+
+    /** Collected by the customer on a market date. */
+    PICKUP_MARKET;
+
+    /** True when the order is collected rather than driven — either pickup flavour. */
+    val isPickup: Boolean
+        get() = this != DELIVERY
+
+    companion object {
+        /**
+         * Reads a stored value, falling back to [DELIVERY] for anything unknown, absent or
+         * malformed. Mirrors the forward-compatibility already applied to `OrderStatus`:
+         * a value written by a newer app version must degrade, never crash the admin list.
+         */
+        fun fromStoredValue(value: String?): FulfillmentType =
+            runCatching { valueOf(value.orEmpty()) }.getOrDefault(DELIVERY)
+    }
+}

--- a/core/domain/src/main/java/com/mtdevelopment/core/model/Order.kt
+++ b/core/domain/src/main/java/com/mtdevelopment/core/model/Order.kt
@@ -19,6 +19,21 @@ import kotlinx.serialization.Serializable
  * @property note Optional instructions provided by the customer.
  * @property isManuallyAdded True if the order was created by an admin (e.g., phone order) rather than through the regular checkout.
  * @property totalPrice Total order amount in cents. Null on documents written before this field existed.
+ * @property fulfillmentType How the order reaches the customer. Defaults to
+ *   [FulfillmentType.DELIVERY], which is also what every order written before this field
+ *   existed reads as — permanently, since older app versions keep writing without it.
+ * @property paymentMode Whether the order was paid in the app or is to be paid on
+ *   collection. Defaults to [PaymentMode.ONLINE].
+ * @property customerPhone Contact number, collected for pickup orders where there is no
+ *   address to fall back on if the customer does not turn up. Null on deliveries.
+ * @property pickupPointId Identifier of the shop or market date the order is collected at.
+ *   Null on deliveries.
+ * @property pickupLabel Human-readable name of the pickup point, e.g. "Marché de
+ *   Pontarlier". **Snapshot, not a reference**: copied here at order time so editing or
+ *   deleting the pickup point later cannot rewrite past orders.
+ * @property pickupAddress Address of the pickup point, snapshotted like [pickupLabel].
+ * @property pickupTimeRange Opening window displayed to the customer, e.g. "8h-13h",
+ *   snapshotted like [pickupLabel].
  */
 @Serializable
 data class Order(
@@ -33,5 +48,12 @@ data class Order(
     val status: OrderStatus,
     val note: String?,
     val isManuallyAdded: Boolean? = false,
-    val totalPrice: Long? = null
+    val totalPrice: Long? = null,
+    val fulfillmentType: FulfillmentType = FulfillmentType.DELIVERY,
+    val paymentMode: PaymentMode = PaymentMode.ONLINE,
+    val customerPhone: String? = null,
+    val pickupPointId: String? = null,
+    val pickupLabel: String? = null,
+    val pickupAddress: String? = null,
+    val pickupTimeRange: String? = null
 )

--- a/core/domain/src/main/java/com/mtdevelopment/core/model/PaymentMode.kt
+++ b/core/domain/src/main/java/com/mtdevelopment/core/model/PaymentMode.kt
@@ -1,0 +1,29 @@
+package com.mtdevelopment.core.model
+
+/**
+ * How an order is paid for.
+ *
+ * Exists to disambiguate `OrderStatus.PENDING`, which otherwise carries two incompatible
+ * meanings once payment on collection is allowed: "payment in flight" and "to be paid on
+ * the spot". The distinction is load-bearing — an [ONLINE] order stuck in PENDING signals
+ * a payment that may have taken the customer's money and needs investigating, while an
+ * [ON_SITE] one is simply waiting for the customer to turn up.
+ *
+ * A separate field rather than a new `OrderStatus` value on purpose: status readers
+ * default anything unknown to PENDING, so an older app version would silently render a
+ * new status as exactly the state we are trying to tell apart. An unknown *field* is
+ * merely ignored.
+ */
+enum class PaymentMode {
+    /** Paid in the app through Google Pay / SumUp before the order is honoured. */
+    ONLINE,
+
+    /** Paid to the shop when the order is collected. */
+    ON_SITE;
+
+    companion object {
+        /** Reads a stored value, falling back to [ONLINE] for anything unknown or absent. */
+        fun fromStoredValue(value: String?): PaymentMode =
+            runCatching { valueOf(value.orEmpty()) }.getOrDefault(ONLINE)
+    }
+}

--- a/core/domain/src/main/java/com/mtdevelopment/core/model/PreparationGroup.kt
+++ b/core/domain/src/main/java/com/mtdevelopment/core/model/PreparationGroup.kt
@@ -1,0 +1,61 @@
+package com.mtdevelopment.core.model
+
+/**
+ * One batch the shop prepares as a unit: everything due on a given date **for a given
+ * destination**.
+ *
+ * The date alone is not enough. A single day can carry a tournée, orders collected at the
+ * shop and orders collected on a market — three batches that leave the workshop separately.
+ * Aggregating them by date would produce one "4 Comté" with no way to tell what goes in
+ * the van, which is exactly the mistake this type exists to prevent.
+ *
+ * @property deliveryDate The `dd/MM/yyyy` date the batch is due.
+ * @property fulfillmentType How that batch leaves the shop.
+ * @property pickupPointId Which pickup point, when [fulfillmentType] is a pickup; null for
+ *   deliveries. Two markets on the same day are therefore two distinct batches.
+ * @property pickupLabel Human-readable name of the pickup point, for display; null for
+ *   deliveries, whose header is the date alone.
+ */
+data class PreparationGroup(
+    val deliveryDate: String,
+    val fulfillmentType: FulfillmentType = FulfillmentType.DELIVERY,
+    val pickupPointId: String? = null,
+    val pickupLabel: String? = null
+) {
+
+    /**
+     * Identifier of the "product prepared" tick for [productName] within this batch.
+     *
+     * Deliveries keep the historical `ddMMyyyy_ProductName` form so the preparation ticks
+     * already stored in Firestore keep matching — this evolution costs the shop no lost
+     * state. Pickups, which never had such documents, get the point appended so two
+     * batches of the same product on the same day cannot collide.
+     */
+    fun statusIdFor(productName: String): String {
+        val base = "${deliveryDate.replace("/", "")}_${productName.replace(" ", "")}"
+        return if (fulfillmentType == FulfillmentType.DELIVERY) {
+            base
+        } else {
+            "${base}_${pickupPointId.orEmpty().replace(" ", "")}"
+        }
+    }
+}
+
+/** The batch this order belongs to. */
+val Order.preparationGroup: PreparationGroup
+    get() = PreparationGroup(
+        deliveryDate = deliveryDate,
+        fulfillmentType = fulfillmentType,
+        pickupPointId = pickupPointId,
+        pickupLabel = pickupLabel
+    )
+
+/**
+ * Keeps only the orders the shop has to drive to on a tournée.
+ *
+ * Used by every consumer of the delivery day — the route optimizer, the maps link, the
+ * tracking service. Without it a click & collect order becomes a stop at the customer's
+ * home address, which is why this filter is a correctness requirement and not a nicety.
+ */
+fun List<Order>.deliveriesOnly(): List<Order> =
+    filter { it.fulfillmentType == FulfillmentType.DELIVERY }

--- a/core/domain/src/test/java/com/mtdevelopment/core/model/PreparationGroupTest.kt
+++ b/core/domain/src/test/java/com/mtdevelopment/core/model/PreparationGroupTest.kt
@@ -1,0 +1,167 @@
+package com.mtdevelopment.core.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PreparationGroupTest {
+
+    private fun order(
+        id: String,
+        deliveryDate: String = "05/07/2026",
+        fulfillmentType: FulfillmentType = FulfillmentType.DELIVERY,
+        pickupPointId: String? = null,
+        pickupLabel: String? = null,
+        products: Map<String, Int> = mapOf("Comté AOP" to 1)
+    ) = Order(
+        id = id,
+        customerName = "Jean Dupont",
+        customerAddress = "1 rue du Comté, 25300 Pontarlier",
+        customerBillingAddress = "1 rue du Comté, 25300 Pontarlier",
+        deliveryDate = deliveryDate,
+        orderDate = "01/07/2026",
+        products = products,
+        status = OrderStatus.PAID,
+        note = null,
+        fulfillmentType = fulfillmentType,
+        pickupPointId = pickupPointId,
+        pickupLabel = pickupLabel
+    )
+
+    @Test
+    fun `an order defaults to a paid-online delivery`() {
+        // The default is what every order written before these fields existed reads as.
+        val order = Order(
+            id = "order-1",
+            customerName = "Jean Dupont",
+            customerAddress = "1 rue du Comté",
+            customerBillingAddress = "1 rue du Comté",
+            deliveryDate = "05/07/2026",
+            orderDate = "01/07/2026",
+            products = emptyMap(),
+            status = OrderStatus.PAID,
+            note = null
+        )
+
+        assertEquals(FulfillmentType.DELIVERY, order.fulfillmentType)
+        assertEquals(PaymentMode.ONLINE, order.paymentMode)
+    }
+
+    @Test
+    fun `an absent or unknown stored fulfillment type reads as a delivery`() {
+        assertEquals(FulfillmentType.DELIVERY, FulfillmentType.fromStoredValue(null))
+        assertEquals(FulfillmentType.DELIVERY, FulfillmentType.fromStoredValue(""))
+        // A mode introduced by a future app version must degrade, not crash the list.
+        assertEquals(FulfillmentType.DELIVERY, FulfillmentType.fromStoredValue("PICKUP_LOCKER"))
+        assertEquals(
+            FulfillmentType.PICKUP_MARKET,
+            FulfillmentType.fromStoredValue("PICKUP_MARKET")
+        )
+    }
+
+    @Test
+    fun `an absent or unknown stored payment mode reads as online`() {
+        assertEquals(PaymentMode.ONLINE, PaymentMode.fromStoredValue(null))
+        assertEquals(PaymentMode.ONLINE, PaymentMode.fromStoredValue("CHEQUE"))
+        assertEquals(PaymentMode.ON_SITE, PaymentMode.fromStoredValue("ON_SITE"))
+    }
+
+    @Test
+    fun `a day mixing a tournee, a shop pickup and a market makes three batches`() {
+        val orders = listOf(
+            order("delivery-1"),
+            order(
+                "shop-1",
+                fulfillmentType = FulfillmentType.PICKUP_SHOP,
+                pickupPointId = "shop",
+                pickupLabel = "La Fromagerie"
+            ),
+            order(
+                "market-1",
+                fulfillmentType = FulfillmentType.PICKUP_MARKET,
+                pickupPointId = "market-pontarlier-0507",
+                pickupLabel = "Marché de Pontarlier"
+            )
+        )
+
+        val batches = orders.groupBy { it.preparationGroup }
+
+        assertEquals(3, batches.size)
+    }
+
+    @Test
+    fun `two markets on the same day are two batches`() {
+        val orders = listOf(
+            order(
+                "market-1",
+                fulfillmentType = FulfillmentType.PICKUP_MARKET,
+                pickupPointId = "market-pontarlier-0507",
+                pickupLabel = "Marché de Pontarlier"
+            ),
+            order(
+                "market-2",
+                fulfillmentType = FulfillmentType.PICKUP_MARKET,
+                pickupPointId = "market-frasne-0507",
+                pickupLabel = "Marché de Frasne"
+            )
+        )
+
+        assertEquals(2, orders.groupBy { it.preparationGroup }.size)
+    }
+
+    @Test
+    fun `deliveries of the same day still aggregate into one batch`() {
+        val orders = listOf(order("delivery-1"), order("delivery-2"))
+
+        assertEquals(1, orders.groupBy { it.preparationGroup }.size)
+    }
+
+    @Test
+    fun `a delivery keeps the historical preparation status id`() {
+        // Changing this format would orphan the ticks already stored in Firestore.
+        val group = PreparationGroup(deliveryDate = "05/07/2026")
+
+        assertEquals("05072026_ComtéAOP", group.statusIdFor("Comté AOP"))
+    }
+
+    @Test
+    fun `two batches of one product on one day get different status ids`() {
+        val delivery = PreparationGroup(deliveryDate = "05/07/2026")
+        val market = PreparationGroup(
+            deliveryDate = "05/07/2026",
+            fulfillmentType = FulfillmentType.PICKUP_MARKET,
+            pickupPointId = "market-pontarlier-0507"
+        )
+        val otherMarket = market.copy(pickupPointId = "market-frasne-0507")
+
+        val ids = listOf(delivery, market, otherMarket).map { it.statusIdFor("Comté AOP") }
+
+        assertEquals(3, ids.toSet().size)
+        assertTrue(ids[1].startsWith("05072026_ComtéAOP_"))
+    }
+
+    @Test
+    fun `deliveriesOnly keeps the tournee stops and drops every pickup`() {
+        val orders = listOf(
+            order("delivery-1"),
+            order("shop-1", fulfillmentType = FulfillmentType.PICKUP_SHOP, pickupPointId = "shop"),
+            order(
+                "market-1",
+                fulfillmentType = FulfillmentType.PICKUP_MARKET,
+                pickupPointId = "market-1"
+            ),
+            order("delivery-2")
+        )
+
+        val routable = orders.deliveriesOnly()
+
+        assertEquals(listOf("delivery-1", "delivery-2"), routable.map { it.id })
+    }
+
+    @Test
+    fun `isPickup separates collected orders from driven ones`() {
+        assertEquals(false, FulfillmentType.DELIVERY.isPickup)
+        assertTrue(FulfillmentType.PICKUP_SHOP.isPickup)
+        assertTrue(FulfillmentType.PICKUP_MARKET.isPickup)
+    }
+}


### PR DESCRIPTION
Stacked on the lot 0 branch (#68) so the diff here is lot 1 alone. Merge in cascade once the whole feature is testable.

**No pickup order can exist yet, so nothing the shop sees changes today** — and that is the point. The admin side must be able to tell a pickup apart from a delivery *before* the first one can be created.

## Schema — additive only, and permanently so

`orders` gains `fulfillment_type`, `payment_mode`, `customer_phone` and a `pickup_*` snapshot. The app is live, so a missing `fulfillment_type` reads as `DELIVERY` **permanently**, not during a migration window: older client versions keep writing orders without it. Both enums parse through `fromStoredValue`, which degrades an unknown value to the default rather than dropping the document — the same forward-compatibility `OrderStatus` already had.

**`payment_mode` is a separate field, not a new `OrderStatus` value.** Once payment on collection exists, `PENDING` carries two incompatible meanings: "payment in flight, the customer may have been charged" and "waiting for someone to turn up". A new status value would be read as plain `PENDING` by older builds — exactly the state we are trying to tell apart. An unknown *field* is merely ignored.

The pickup label, address and time range are **copied onto the order**, not referenced by id, so editing or deleting a market date later cannot rewrite orders already placed.

## The correctness fix

`DeliveryHelperScreen` and `DeliveryTrackingService` now filter through `deliveriesOnly()` before anything reaches the route optimizer, the maps link or the tracking notification. Without it a click & collect order becomes a stop at the customer's home address. The filter is applied once per consumer, at the source of the list, rather than at each of the four places that read an address off it.

## Preparation

Grouping moves from the date alone to `(date, fulfillment, pickup point)`: a day mixing a tournée, shop pickups and a market would otherwise aggregate into one "4 Comté" with no way to tell what goes in the van.

Delivery batches **keep the historical `ddMMyyyy_ProductName` status id**, so the preparation ticks already stored in Firestore keep matching and the shop loses no state; only pickup batches append the point. The header still shows the date alone for deliveries and names the point only for pickups, so nothing on screen moves until lot 3.

## Verification

- Both flavors compile.
- 14 new unit tests: the three-batch split, two markets on one day, the legacy status id, `deliveriesOnly`, the enum fallbacks, and a decode of an order document written without any of the new keys.
- Full suite (client, admin, unflavored) at the documented baseline — the same 2 `AdminViewModelTest` failures, no new ones.
- **No Firestore write of any kind was performed.** The mappings are proven by unit tests on the DTO.

## Needs your sign-off

This is the schema change flagged in the spec. Nothing writes a pickup order yet, so merging it early is safe, but the `orders` shape is the gated part.

Noted in passing, left out on purpose: `getAllOrders` never mapped `customer_email` or `total_price`, so the admin app has never seen either. Out of scope here; spun off separately since `total_price` is needed for the lot 5 "encaissé" action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)