### PR TITLE
Lot 2 — let the shop declare where orders can be collected

### DIFF
--- a/admin/data/src/main/java/com/mtdevelopment/admin/data/model/DataPickupPoint.kt
+++ b/admin/data/src/main/java/com/mtdevelopment/admin/data/model/DataPickupPoint.kt
@@ -1,0 +1,65 @@
+package com.mtdevelopment.admin.data.model
+
+import androidx.annotation.Keep
+import com.mtdevelopment.core.model.PickupPoint
+import com.mtdevelopment.core.model.PickupPointType
+
+/**
+ * Data Transfer Object for a pickup point, used for Firestore serialization.
+ *
+ * Firestore's `set`/`add` use their own reflective POJO mapper, not kotlinx.serialization, so
+ * the **Kotlin property names are the Firestore field names** — hence the snake_case, and hence
+ * the fact that a `@SerialName` here would be purely decorative. Same rule as
+ * [DataDeliveryPath]; get it backwards and the document silently gains camelCase keys nothing
+ * reads.
+ *
+ * [type] is stored as the enum name rather than the enum itself so an older build reading a
+ * type it does not know degrades through [PickupPointType.fromStoredValue] instead of failing
+ * to map the document.
+ *
+ * Every field carries a default: Firestore's mapper needs a no-arg construction path, and a
+ * document written by a future version with fewer keys must still map.
+ */
+@Keep
+data class DataPickupPoint(
+    val id: String = "",
+    val type: String = PickupPointType.SHOP.name,
+    val label: String = "",
+    val address: String = "",
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val time_range: String = "",
+    val opening_days: List<String> = emptyList(),
+    val closed_dates: List<String> = emptyList(),
+    val date: String? = null
+)
+
+/** Maps a domain [PickupPoint] to its Firestore DTO. */
+fun PickupPoint.toDataPickupPoint() = DataPickupPoint(
+    id = id,
+    type = type.name,
+    label = label,
+    address = address,
+    latitude = latitude,
+    longitude = longitude,
+    time_range = timeRange,
+    // The fields that do not apply to this kind of point are written empty rather than left
+    // to carry stale values from a point that changed type mid-edit.
+    opening_days = if (type == PickupPointType.SHOP) openingDays else emptyList(),
+    closed_dates = if (type == PickupPointType.SHOP) closedDates else emptyList(),
+    date = if (type == PickupPointType.MARKET) date else null
+)
+
+/** Maps a Firestore DTO back to the domain model. */
+fun DataPickupPoint.toPickupPoint() = PickupPoint(
+    id = id,
+    type = PickupPointType.fromStoredValue(type),
+    label = label,
+    address = address,
+    latitude = latitude,
+    longitude = longitude,
+    timeRange = time_range,
+    openingDays = opening_days,
+    closedDates = closed_dates,
+    date = date
+)

--- a/admin/data/src/main/java/com/mtdevelopment/admin/data/repository/FirebaseAdminRepositoryImpl.kt
+++ b/admin/data/src/main/java/com/mtdevelopment/admin/data/repository/FirebaseAdminRepositoryImpl.kt
@@ -2,11 +2,14 @@ package com.mtdevelopment.admin.data.repository
 
 import com.mtdevelopment.admin.data.BuildConfig
 import com.mtdevelopment.admin.data.model.toDataDeliveryPath
+import com.mtdevelopment.admin.data.model.toDataPickupPoint
+import com.mtdevelopment.admin.data.model.toPickupPoint
 import com.mtdevelopment.admin.data.source.FirestoreAdminDatasource
 import com.mtdevelopment.admin.domain.repository.FirebaseAdminRepository
 import com.mtdevelopment.core.model.DeliveryPath
 import com.mtdevelopment.core.model.Order
 import com.mtdevelopment.core.model.OrderStatus
+import com.mtdevelopment.core.model.PickupPoint
 import com.mtdevelopment.core.model.PreparationStatus
 import com.mtdevelopment.core.model.toData
 import com.mtdevelopment.core.model.toDomain
@@ -102,6 +105,55 @@ class FirebaseAdminRepositoryImpl(
         }
 
         return finalResult ?: result
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Pickup Point Management
+    // Each modification triggers a call to saveNewDatabasePickupUpdate, on the same
+    // principle as the delivery paths above: without the bump, clients keep serving a
+    // stale cache and would let customers order on a market date that no longer exists.
+    ///////////////////////////////////////////////////////////////////////////
+    override suspend fun getAllPickupPoints(): Result<List<PickupPoint>> {
+        return firestore.getAllPickupPoints().map { points ->
+            points.map { it.toPickupPoint() }
+        }
+    }
+
+    override suspend fun addNewPickupPoint(point: PickupPoint): Result<Unit> {
+        val result = firestore.addNewPickupPoint(point = point.toDataPickupPoint())
+        var finalResult: Result<Unit>? = null
+
+        result.onSuccess {
+            finalResult = saveNewDatabasePickupUpdate(System.currentTimeMillis())
+        }
+
+        return finalResult ?: result
+    }
+
+    override suspend fun updatePickupPoint(point: PickupPoint): Result<Unit> {
+        val result = firestore.updatePickupPoint(point = point.toDataPickupPoint())
+        var finalResult: Result<Unit>? = null
+
+        result.onSuccess {
+            finalResult = saveNewDatabasePickupUpdate(System.currentTimeMillis())
+        }
+
+        return finalResult ?: result
+    }
+
+    override suspend fun deletePickupPoint(point: PickupPoint): Result<Unit> {
+        val result = firestore.deletePickupPoint(point = point.toDataPickupPoint())
+        var finalResult: Result<Unit>? = null
+
+        result.onSuccess {
+            finalResult = saveNewDatabasePickupUpdate(System.currentTimeMillis())
+        }
+
+        return finalResult ?: result
+    }
+
+    override suspend fun saveNewDatabasePickupUpdate(timestamp: Long): Result<Unit> {
+        return firestore.saveNewDatabasePickupUpdate(timestamp)
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/admin/data/src/main/java/com/mtdevelopment/admin/data/source/FirestoreAdminDatasource.kt
+++ b/admin/data/src/main/java/com/mtdevelopment/admin/data/source/FirestoreAdminDatasource.kt
@@ -6,10 +6,12 @@ import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.firestore
 import com.mtdevelopment.admin.data.model.DataDeliveryPath
+import com.mtdevelopment.admin.data.model.DataPickupPoint
 import com.mtdevelopment.core.model.FulfillmentType
 import com.mtdevelopment.core.model.OrderData
 import com.mtdevelopment.core.model.OrderStatus
 import com.mtdevelopment.core.model.PaymentMode
+import com.mtdevelopment.core.model.PickupPointType
 import com.mtdevelopment.core.model.PreparationStatusData
 import com.mtdevelopment.core.model.ProductData
 import kotlinx.coroutines.tasks.await
@@ -144,6 +146,103 @@ class FirestoreAdminDatasource(
         return try {
             firestore.collection("database_update")
                 .document("path_timestamp")
+                .set(mapOf("last_update" to Timestamp(Instant.ofEpochMilli(timestamp))))
+                .await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Pickup Point Management
+    ///////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Reads every pickup point, mapping documents by hand for the same reason
+     * [getAllOrders] does: the keys are snake_case and the type needs an explicit enum
+     * conversion `toObject` cannot perform.
+     *
+     * An empty list is a legitimate answer here — the shop may simply not have configured
+     * a point yet. That is **not** true of the client-side reader, where an empty read is
+     * indistinguishable from an offline Firestore returning nothing successfully, and must
+     * be treated as a failure instead.
+     */
+    suspend fun getAllPickupPoints(): Result<List<DataPickupPoint>> {
+        return try {
+            val snapshot = firestore.collection("pickup_points").get().await()
+            Result.success(
+                snapshot.documents.map { item ->
+                    DataPickupPoint(
+                        id = item.id,
+                        type = item.data?.get("type") as? String
+                            ?: PickupPointType.SHOP.name,
+                        label = item.data?.get("label") as? String ?: "",
+                        address = item.data?.get("address") as? String ?: "",
+                        // Firestore has no Float/Int: read through Number, never cast
+                        // straight to Double.
+                        latitude = (item.data?.get("latitude") as? Number)?.toDouble(),
+                        longitude = (item.data?.get("longitude") as? Number)?.toDouble(),
+                        time_range = item.data?.get("time_range") as? String ?: "",
+                        opening_days = (item.data?.get("opening_days") as? List<*>)
+                            ?.filterIsInstance<String>() ?: emptyList(),
+                        closed_dates = (item.data?.get("closed_dates") as? List<*>)
+                            ?.filterIsInstance<String>() ?: emptyList(),
+                        date = item.data?.get("date") as? String
+                    )
+                }
+            )
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun addNewPickupPoint(point: DataPickupPoint): Result<Unit> {
+        return try {
+            firestore.collection("pickup_points")
+                .add(point)
+                .await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun updatePickupPoint(point: DataPickupPoint): Result<Unit> {
+        return try {
+            firestore.collection("pickup_points")
+                .document(point.id)
+                .set(point)
+                .await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun deletePickupPoint(point: DataPickupPoint): Result<Unit> {
+        return try {
+            firestore.collection("pickup_points")
+                .document(point.id)
+                .delete()
+                .await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Updates the global timestamp for pickup point changes.
+     *
+     * The third such document, alongside `products_timestamp` and `path_timestamp`. Every
+     * write to `pickup_points` must bump it: the client only knows to refresh when the
+     * timestamp moves, so skipping it leaves customers ordering against a stale cache.
+     */
+    suspend fun saveNewDatabasePickupUpdate(timestamp: Long): Result<Unit> {
+        return try {
+            firestore.collection("database_update")
+                .document("pickup_timestamp")
                 .set(mapOf("last_update" to Timestamp(Instant.ofEpochMilli(timestamp))))
                 .await()
             Result.success(Unit)

--- a/admin/data/src/test/java/com/mtdevelopment/admin/data/model/DataPickupPointTest.kt
+++ b/admin/data/src/test/java/com/mtdevelopment/admin/data/model/DataPickupPointTest.kt
@@ -1,0 +1,91 @@
+package com.mtdevelopment.admin.data.model
+
+import com.mtdevelopment.core.model.PickupPoint
+import com.mtdevelopment.core.model.PickupPointType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DataPickupPointTest {
+
+    private fun shop() = PickupPoint(
+        id = "shop",
+        type = PickupPointType.SHOP,
+        label = "La Fromagerie",
+        address = "3 Grande Rue, 25300 Pontarlier",
+        latitude = 46.9036,
+        longitude = 6.3553,
+        timeRange = "9h-12h / 15h-19h",
+        openingDays = listOf("TUESDAY", "SATURDAY"),
+        closedDates = listOf("15/08/2026")
+    )
+
+    private fun market() = PickupPoint(
+        id = "market-1",
+        type = PickupPointType.MARKET,
+        label = "Marché de Pontarlier",
+        address = "Place Saint-Bénigne, 25300 Pontarlier",
+        timeRange = "8h-13h",
+        date = "15/08/2026"
+    )
+
+    @Test
+    fun `a shop round-trips through the Firestore DTO`() {
+        assertEquals(shop(), shop().toDataPickupPoint().toPickupPoint())
+    }
+
+    @Test
+    fun `a market round-trips through the Firestore DTO`() {
+        assertEquals(market(), market().toDataPickupPoint().toPickupPoint())
+    }
+
+    @Test
+    fun `a market never carries opening days or closures`() {
+        // A draft edited as a shop and then switched to a market keeps both halves in
+        // memory; only the ones that still apply reach Firestore.
+        val switched = market().copy(
+            openingDays = listOf("TUESDAY"),
+            closedDates = listOf("01/01/2027")
+        )
+
+        val stored = switched.toDataPickupPoint()
+
+        assertTrue(stored.opening_days.isEmpty())
+        assertTrue(stored.closed_dates.isEmpty())
+        assertEquals("15/08/2026", stored.date)
+    }
+
+    @Test
+    fun `a shop never carries a market date`() {
+        val switched = shop().copy(date = "15/08/2026")
+
+        val stored = switched.toDataPickupPoint()
+
+        assertNull(stored.date)
+        assertEquals(listOf("TUESDAY", "SATURDAY"), stored.opening_days)
+    }
+
+    @Test
+    fun `the type is stored as its name and read back defensively`() {
+        assertEquals("MARKET", market().toDataPickupPoint().type)
+        // A type written by a future app version degrades instead of failing the mapping.
+        assertEquals(
+            PickupPointType.SHOP,
+            DataPickupPoint(type = "DRIVE_THROUGH").toPickupPoint().type
+        )
+    }
+
+    @Test
+    fun `an empty document maps to an empty shop rather than failing`() {
+        // Firestore's reflective mapper needs every field defaulted; this is the shape a
+        // document written by a future version with fewer keys arrives as.
+        val mapped = DataPickupPoint().toPickupPoint()
+
+        assertEquals(PickupPointType.SHOP, mapped.type)
+        assertEquals("", mapped.label)
+        assertNull(mapped.date)
+        assertNull(mapped.latitude)
+        assertTrue(mapped.openingDays.isEmpty())
+    }
+}

--- a/admin/domain/src/main/java/com/mtdevelopment/admin/domain/di/adminModule.kt
+++ b/admin/domain/src/main/java/com/mtdevelopment/admin/domain/di/adminModule.kt
@@ -1,9 +1,13 @@
 package com.mtdevelopment.admin.domain.di
 
 import com.mtdevelopment.admin.domain.usecase.AddNewPathUseCase
+import com.mtdevelopment.admin.domain.usecase.AddNewPickupPointUseCase
 import com.mtdevelopment.admin.domain.usecase.AddNewProductUseCase
 import com.mtdevelopment.admin.domain.usecase.DeletePathUseCase
+import com.mtdevelopment.admin.domain.usecase.DeletePickupPointUseCase
 import com.mtdevelopment.admin.domain.usecase.DeleteProductUseCase
+import com.mtdevelopment.admin.domain.usecase.GetAllPickupPointsUseCase
+import com.mtdevelopment.admin.domain.usecase.UpdatePickupPointUseCase
 import com.mtdevelopment.admin.domain.usecase.DetermineNextDeliveryStopUseCase
 import com.mtdevelopment.admin.domain.usecase.GetAllOrdersUseCase
 import com.mtdevelopment.admin.domain.usecase.GetCurrentLocationOnceUseCase
@@ -31,6 +35,11 @@ val adminDomainModule = module {
     factory { UpdateDeliveryPathUseCase(get()) }
     factory { DeletePathUseCase(get()) }
     factory { AddNewPathUseCase(get()) }
+
+    factory { GetAllPickupPointsUseCase(get()) }
+    factory { AddNewPickupPointUseCase(get()) }
+    factory { UpdatePickupPointUseCase(get()) }
+    factory { DeletePickupPointUseCase(get()) }
 
     factory { GetAllOrdersUseCase(get()) }
 

--- a/admin/domain/src/main/java/com/mtdevelopment/admin/domain/repository/FirebaseAdminRepository.kt
+++ b/admin/domain/src/main/java/com/mtdevelopment/admin/domain/repository/FirebaseAdminRepository.kt
@@ -2,6 +2,7 @@ package com.mtdevelopment.admin.domain.repository
 
 import com.mtdevelopment.core.model.DeliveryPath
 import com.mtdevelopment.core.model.Order
+import com.mtdevelopment.core.model.PickupPoint
 import com.mtdevelopment.core.model.PreparationStatus
 import com.mtdevelopment.core.model.Product
 
@@ -66,6 +67,40 @@ interface FirebaseAdminRepository {
      * @return Result indicating success or failure.
      */
     suspend fun deleteDeliveryPath(path: DeliveryPath): Result<Unit>
+
+    /**
+     * Retrieves every configured pickup point (the shop and each market date).
+     * @return Result carrying the points, or the failure that prevented reading them.
+     */
+    suspend fun getAllPickupPoints(): Result<List<PickupPoint>>
+
+    /**
+     * Adds a new pickup point. Also bumps the pickup timestamp.
+     * @param point The pickup point to add.
+     * @return Result indicating success or failure.
+     */
+    suspend fun addNewPickupPoint(point: PickupPoint): Result<Unit>
+
+    /**
+     * Updates an existing pickup point. Also bumps the pickup timestamp.
+     * @param point The pickup point with updated information.
+     * @return Result indicating success or failure.
+     */
+    suspend fun updatePickupPoint(point: PickupPoint): Result<Unit>
+
+    /**
+     * Deletes a pickup point. Also bumps the pickup timestamp.
+     * @param point The pickup point to delete.
+     * @return Result indicating success or failure.
+     */
+    suspend fun deletePickupPoint(point: PickupPoint): Result<Unit>
+
+    /**
+     * Updates the timestamp for the last pickup point database update.
+     * @param timestamp The new timestamp to save.
+     * @return Result indicating success or failure.
+     */
+    suspend fun saveNewDatabasePickupUpdate(timestamp: Long): Result<Unit>
 
     /**
      * Retrieves all orders from the database.

--- a/admin/domain/src/main/java/com/mtdevelopment/admin/domain/usecase/PickupPointUseCases.kt
+++ b/admin/domain/src/main/java/com/mtdevelopment/admin/domain/usecase/PickupPointUseCases.kt
@@ -1,0 +1,63 @@
+package com.mtdevelopment.admin.domain.usecase
+
+import com.mtdevelopment.admin.domain.repository.FirebaseAdminRepository
+import com.mtdevelopment.core.domain.toTimeStamp
+import com.mtdevelopment.core.model.PickupPoint
+import com.mtdevelopment.core.model.PickupPointType
+
+/**
+ * Retrieves every pickup point, ordered the way the shop thinks about them: the shop first,
+ * then the market dates chronologically. Firestore returns documents in no useful order, so
+ * sorting here keeps every consumer consistent without each re-deciding.
+ */
+class GetAllPickupPointsUseCase(
+    private val firebaseAdminRepository: FirebaseAdminRepository
+) {
+    suspend operator fun invoke(): Result<List<PickupPoint>> {
+        return firebaseAdminRepository.getAllPickupPoints().map { points ->
+            points.sortedWith(
+                compareBy<PickupPoint> { it.type != PickupPointType.SHOP }
+                    .thenBy { it.date?.toTimeStamp() ?: 0L }
+                    .thenBy { it.label }
+            )
+        }
+    }
+}
+
+/**
+ * Adds a new pickup point.
+ *
+ * Refuses an incomplete one rather than storing it: a shop with no opening day or a market
+ * with no date is invisible to every customer, so saving it would look like a silent failure.
+ */
+class AddNewPickupPointUseCase(
+    private val firebaseAdminRepository: FirebaseAdminRepository
+) {
+    suspend operator fun invoke(point: PickupPoint): Result<Unit> {
+        if (!point.canBeSaved) {
+            return Result.failure(IllegalArgumentException("Point de retrait incomplet"))
+        }
+        return firebaseAdminRepository.addNewPickupPoint(point)
+    }
+}
+
+/** Updates an existing pickup point, with the same completeness guard as creation. */
+class UpdatePickupPointUseCase(
+    private val firebaseAdminRepository: FirebaseAdminRepository
+) {
+    suspend operator fun invoke(point: PickupPoint): Result<Unit> {
+        if (!point.canBeSaved) {
+            return Result.failure(IllegalArgumentException("Point de retrait incomplet"))
+        }
+        return firebaseAdminRepository.updatePickupPoint(point)
+    }
+}
+
+/** Deletes a pickup point. */
+class DeletePickupPointUseCase(
+    private val firebaseAdminRepository: FirebaseAdminRepository
+) {
+    suspend operator fun invoke(point: PickupPoint): Result<Unit> {
+        return firebaseAdminRepository.deletePickupPoint(point)
+    }
+}

--- a/admin/domain/src/test/java/com/mtdevelopment/admin/domain/usecase/PickupPointUseCasesTest.kt
+++ b/admin/domain/src/test/java/com/mtdevelopment/admin/domain/usecase/PickupPointUseCasesTest.kt
@@ -1,0 +1,98 @@
+package com.mtdevelopment.admin.domain.usecase
+
+import com.mtdevelopment.admin.domain.repository.FirebaseAdminRepository
+import com.mtdevelopment.core.model.PickupPoint
+import com.mtdevelopment.core.model.PickupPointType
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PickupPointUseCasesTest {
+
+    private val repository: FirebaseAdminRepository = mockk(relaxed = true)
+
+    private fun market(id: String, date: String, label: String = "Marché $id") = PickupPoint(
+        id = id,
+        type = PickupPointType.MARKET,
+        label = label,
+        address = "Place Saint-Bénigne, 25300 Pontarlier",
+        date = date
+    )
+
+    private fun shop() = PickupPoint(
+        id = "shop",
+        type = PickupPointType.SHOP,
+        label = "La Fromagerie",
+        address = "3 Grande Rue, 25300 Pontarlier",
+        openingDays = listOf("SATURDAY")
+    )
+
+    @Test
+    fun `points come back with the shop first and markets in chronological order`() = runTest {
+        coEvery { repository.getAllPickupPoints() } returns Result.success(
+            listOf(
+                market("m2", "20/09/2026"),
+                shop(),
+                market("m1", "15/08/2026")
+            )
+        )
+
+        val result = GetAllPickupPointsUseCase(repository).invoke()
+
+        assertEquals(
+            listOf("shop", "m1", "m2"),
+            result.getOrThrow().map { it.id }
+        )
+    }
+
+    @Test
+    fun `a read failure is propagated rather than flattened to an empty list`() = runTest {
+        // An empty list would tell the shop it has no market dates configured, which is a
+        // very different statement from "we could not read them".
+        coEvery { repository.getAllPickupPoints() } returns Result.failure(RuntimeException("offline"))
+
+        val result = GetAllPickupPointsUseCase(repository).invoke()
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `an incomplete point is refused instead of being stored`() = runTest {
+        val incomplete = shop().copy(openingDays = emptyList())
+
+        val added = AddNewPickupPointUseCase(repository).invoke(incomplete)
+        val updated = UpdatePickupPointUseCase(repository).invoke(incomplete)
+
+        assertTrue(added.isFailure)
+        assertTrue(updated.isFailure)
+        coVerify(exactly = 0) { repository.addNewPickupPoint(any()) }
+        coVerify(exactly = 0) { repository.updatePickupPoint(any()) }
+    }
+
+    @Test
+    fun `a complete point reaches the repository`() = runTest {
+        coEvery { repository.addNewPickupPoint(any()) } returns Result.success(Unit)
+
+        val result = AddNewPickupPointUseCase(repository).invoke(market("m1", "15/08/2026"))
+
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 1) { repository.addNewPickupPoint(any()) }
+    }
+
+    @Test
+    fun `deleting does not require a complete point`() = runTest {
+        // Whatever made a stored point invalid must not block removing it.
+        coEvery { repository.deletePickupPoint(any()) } returns Result.success(Unit)
+
+        val result = DeletePickupPointUseCase(repository).invoke(
+            shop().copy(openingDays = emptyList())
+        )
+
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 1) { repository.deletePickupPoint(any()) }
+    }
+}

--- a/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/di/adminModule.kt
+++ b/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/di/adminModule.kt
@@ -27,6 +27,11 @@ val adminPresentationModule = module {
             get(),
             get(),
             get(),
+            // Pickup points: get all, add, update, delete.
+            get(),
+            get(),
+            get(),
+            get(),
         )
     }
 }

--- a/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/model/PickupPointsState.kt
+++ b/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/model/PickupPointsState.kt
@@ -1,0 +1,18 @@
+package com.mtdevelopment.admin.presentation.model
+
+import com.mtdevelopment.core.model.PickupPoint
+
+/**
+ * UI state of the pickup point management screens.
+ *
+ * @property points Every configured point: the shop first, then market dates in
+ *   chronological order.
+ * @property isLoading True while a read or a write is in flight.
+ * @property error Message to surface, or null. Set on a failed read or write so a silent
+ *   no-op is never mistaken for "there is nothing configured".
+ */
+data class PickupPointsState(
+    val points: List<PickupPoint> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null
+)

--- a/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/viewmodel/AdminViewModel.kt
+++ b/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/viewmodel/AdminViewModel.kt
@@ -13,7 +13,11 @@ import com.mtdevelopment.admin.domain.usecase.GetAllOrdersUseCase
 import com.mtdevelopment.admin.domain.usecase.GetCurrentLocationOnceUseCase
 import com.mtdevelopment.admin.domain.usecase.GetIsInTrackingModeUseCase
 import com.mtdevelopment.admin.domain.usecase.GetOptimizedDeliveryUseCase
+import com.mtdevelopment.admin.domain.usecase.AddNewPickupPointUseCase
+import com.mtdevelopment.admin.domain.usecase.DeletePickupPointUseCase
+import com.mtdevelopment.admin.domain.usecase.GetAllPickupPointsUseCase
 import com.mtdevelopment.admin.domain.usecase.GetPreparationStatusesUseCase
+import com.mtdevelopment.admin.domain.usecase.UpdatePickupPointUseCase
 import com.mtdevelopment.admin.domain.usecase.GetShouldShowBatterieOptimizationUseCase
 import com.mtdevelopment.admin.domain.usecase.UpdateDeliveryPathUseCase
 import com.mtdevelopment.admin.domain.usecase.UpdatePreparationStatusUseCase
@@ -21,9 +25,11 @@ import com.mtdevelopment.admin.domain.usecase.UpdateProductUseCase
 import com.mtdevelopment.admin.domain.usecase.UpdateShouldShowBatterieOptimizationUseCase
 import com.mtdevelopment.admin.domain.usecase.UploadImageUseCase
 import com.mtdevelopment.admin.presentation.model.OrderScreenState
+import com.mtdevelopment.admin.presentation.model.PickupPointsState
 import com.mtdevelopment.core.domain.toTimeStamp
 import com.mtdevelopment.core.model.AutoCompleteSuggestion
 import com.mtdevelopment.core.model.DeliveryPath
+import com.mtdevelopment.core.model.PickupPoint
 import com.mtdevelopment.core.model.Order
 import com.mtdevelopment.core.model.PreparationStatus
 import com.mtdevelopment.core.presentation.sharedModels.UiProductObject
@@ -65,7 +71,11 @@ class AdminViewModel(
     private val shouldShowBatterieOptimizationUseCase: UpdateShouldShowBatterieOptimizationUseCase,
     private val getShouldShowBatterieOptimizationUseCase: GetShouldShowBatterieOptimizationUseCase,
     private val getPreparationStatusesUseCase: GetPreparationStatusesUseCase,
-    private val updatePreparationStatusUseCase: UpdatePreparationStatusUseCase
+    private val updatePreparationStatusUseCase: UpdatePreparationStatusUseCase,
+    private val getAllPickupPointsUseCase: GetAllPickupPointsUseCase,
+    private val addNewPickupPointUseCase: AddNewPickupPointUseCase,
+    private val updatePickupPointUseCase: UpdatePickupPointUseCase,
+    private val deletePickupPointUseCase: DeletePickupPointUseCase
 ) : ViewModel(), KoinComponent {
 
     ///////////////////////////////////////////////////////////////////////////
@@ -73,6 +83,9 @@ class AdminViewModel(
     ///////////////////////////////////////////////////////////////////////////
     private val _orderScreenState = MutableStateFlow(OrderScreenState())
     val orderScreenState = _orderScreenState.asStateFlow()
+
+    private val _pickupPointsState = MutableStateFlow(PickupPointsState())
+    val pickupPointsState = _pickupPointsState.asStateFlow()
 
     /**
      * Internal state for debouncing address autocomplete queries.
@@ -270,6 +283,85 @@ class AdminViewModel(
                 onFailure.invoke()
             })
         }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Pickup Point Operations
+    ///////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Loads every pickup point.
+     *
+     * A read failure sets [PickupPointsState.error] and leaves the previous list alone:
+     * showing an empty screen would tell the shop it has no market dates configured, which
+     * is a very different statement from "we could not read them".
+     */
+    fun getAllPickupPoints() {
+        _pickupPointsState.update { it.copy(isLoading = true, error = null) }
+        viewModelScope.launch {
+            getAllPickupPointsUseCase.invoke()
+                .onSuccess { points ->
+                    _pickupPointsState.update {
+                        it.copy(points = points, isLoading = false)
+                    }
+                }
+                .onFailure {
+                    _pickupPointsState.update { state ->
+                        state.copy(
+                            isLoading = false,
+                            error = "Impossible de charger les points de retrait."
+                        )
+                    }
+                }
+        }
+    }
+
+    /** Creates the point when it has no id yet, updates it otherwise. */
+    fun savePickupPoint(point: PickupPoint, onSuccess: () -> Unit) {
+        _pickupPointsState.update { it.copy(isLoading = true, error = null) }
+        viewModelScope.launch {
+            val result = if (point.id.isBlank()) {
+                addNewPickupPointUseCase.invoke(point)
+            } else {
+                updatePickupPointUseCase.invoke(point)
+            }
+            result
+                .onSuccess {
+                    _pickupPointsState.update { it.copy(isLoading = false) }
+                    onSuccess.invoke()
+                }
+                .onFailure {
+                    _pickupPointsState.update { state ->
+                        state.copy(
+                            isLoading = false,
+                            error = "Impossible d'enregistrer ce point de retrait."
+                        )
+                    }
+                }
+        }
+    }
+
+    fun deletePickupPoint(point: PickupPoint, onSuccess: () -> Unit) {
+        _pickupPointsState.update { it.copy(isLoading = true, error = null) }
+        viewModelScope.launch {
+            deletePickupPointUseCase.invoke(point)
+                .onSuccess {
+                    _pickupPointsState.update { it.copy(isLoading = false) }
+                    onSuccess.invoke()
+                }
+                .onFailure {
+                    _pickupPointsState.update { state ->
+                        state.copy(
+                            isLoading = false,
+                            error = "Impossible de supprimer ce point de retrait."
+                        )
+                    }
+                }
+        }
+    }
+
+    fun clearPickupPointError() {
+        _pickupPointsState.update { it.copy(error = null) }
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/admin/presentation/src/test/java/com/mtdevelopment/admin/presentation/viewmodel/AdminViewModelTest.kt
+++ b/admin/presentation/src/test/java/com/mtdevelopment/admin/presentation/viewmodel/AdminViewModelTest.kt
@@ -9,7 +9,11 @@ import com.mtdevelopment.admin.domain.usecase.GetAllOrdersUseCase
 import com.mtdevelopment.admin.domain.usecase.GetCurrentLocationOnceUseCase
 import com.mtdevelopment.admin.domain.usecase.GetIsInTrackingModeUseCase
 import com.mtdevelopment.admin.domain.usecase.GetOptimizedDeliveryUseCase
+import com.mtdevelopment.admin.domain.usecase.AddNewPickupPointUseCase
+import com.mtdevelopment.admin.domain.usecase.DeletePickupPointUseCase
+import com.mtdevelopment.admin.domain.usecase.GetAllPickupPointsUseCase
 import com.mtdevelopment.admin.domain.usecase.GetPreparationStatusesUseCase
+import com.mtdevelopment.admin.domain.usecase.UpdatePickupPointUseCase
 import com.mtdevelopment.admin.domain.usecase.GetShouldShowBatterieOptimizationUseCase
 import com.mtdevelopment.admin.domain.usecase.UpdateDeliveryPathUseCase
 import com.mtdevelopment.admin.domain.usecase.UpdatePreparationStatusUseCase
@@ -70,6 +74,10 @@ class AdminViewModelTest {
         mockk(relaxed = true)
     private val updatePreparationStatusUseCase: UpdatePreparationStatusUseCase =
         mockk(relaxed = true)
+    private val getAllPickupPointsUseCase: GetAllPickupPointsUseCase = mockk(relaxed = true)
+    private val addNewPickupPointUseCase: AddNewPickupPointUseCase = mockk(relaxed = true)
+    private val updatePickupPointUseCase: UpdatePickupPointUseCase = mockk(relaxed = true)
+    private val deletePickupPointUseCase: DeletePickupPointUseCase = mockk(relaxed = true)
 
     @Before
     fun setUp() {
@@ -101,7 +109,11 @@ class AdminViewModelTest {
         updateShouldShowBatterieOptimizationUseCase,
         getShouldShowBatterieOptimizationUseCase,
         getPreparationStatusesUseCase,
-        updatePreparationStatusUseCase
+        updatePreparationStatusUseCase,
+        getAllPickupPointsUseCase,
+        addNewPickupPointUseCase,
+        updatePickupPointUseCase,
+        deletePickupPointUseCase
     )
 
     private fun product(imageUrl: String?) = UiProductObject(

--- a/app/src/admin/java/com/mtdevelopment/lafromagerie/navigation/NavGraph.kt
+++ b/app/src/admin/java/com/mtdevelopment/lafromagerie/navigation/NavGraph.kt
@@ -25,7 +25,10 @@ import com.mtdevelopment.core.presentation.theme.ui.scaleOutOfContainer
 import com.mtdevelopment.core.util.koinViewModel
 import com.mtdevelopment.delivery.presentation.screen.DeliveryOptionScreen
 import com.mtdevelopment.delivery.presentation.screen.PATH_LIST_NEEDS_REFRESH
+import com.mtdevelopment.delivery.presentation.screen.PICKUP_LIST_NEEDS_REFRESH
 import com.mtdevelopment.delivery.presentation.screen.PathEditScreen
+import com.mtdevelopment.delivery.presentation.screen.PickupPointEditScreen
+import com.mtdevelopment.delivery.presentation.screen.PickupPointsScreen
 import com.mtdevelopment.details.presentation.composable.DetailScreen
 import com.mtdevelopment.home.presentation.composable.HomeScreen
 
@@ -162,10 +165,56 @@ fun NavGraph(
                 navigateToPathEdit = { pathId ->
                     navController.navigate(PathEditScreenDestination(pathId))
                 },
+                navigateToPickupPoints = {
+                    navController.navigate(PickupPointsScreenDestination)
+                },
                 navigateBack = {
                     cartViewModel.setCartVisibility(false)
                     navController.navigateUp()
                 })
+        }
+
+        composable<PickupPointsScreenDestination>(
+            enterTransition = { scaleIntoContainer() },
+            exitTransition = { scaleOutOfContainer(ScaleTransitionDirection.INWARDS) },
+            popEnterTransition = { scaleIntoContainer(ScaleTransitionDirection.OUTWARDS) },
+            popExitTransition = { scaleOutOfContainer() }
+        ) { backStackEntry ->
+            // Set by the editor on its way back, same handshake as the path list: the two
+            // screens own separate ViewModel instances, so the list cannot otherwise know a
+            // point was written.
+            val pointsChanged = backStackEntry.savedStateHandle
+                .getStateFlow(PICKUP_LIST_NEEDS_REFRESH, false)
+                .collectAsState()
+
+            PickupPointsScreen(
+                pointsChanged = pointsChanged.value,
+                onPointsChangeHandled = {
+                    backStackEntry.savedStateHandle[PICKUP_LIST_NEEDS_REFRESH] = false
+                },
+                navigateToPointEdit = { pointId ->
+                    navController.navigate(PickupPointEditScreenDestination(pointId))
+                }
+            )
+        }
+
+        composable<PickupPointEditScreenDestination>(
+            enterTransition = { scaleIntoContainer() },
+            exitTransition = { scaleOutOfContainer(ScaleTransitionDirection.INWARDS) },
+            popEnterTransition = { scaleIntoContainer(ScaleTransitionDirection.OUTWARDS) },
+            popExitTransition = { scaleOutOfContainer() }
+        ) { backStackEntry ->
+            val args = backStackEntry.toRoute<PickupPointEditScreenDestination>()
+
+            PickupPointEditScreen(
+                pointId = args.pointId,
+                onSaved = {
+                    navController.previousBackStackEntry
+                        ?.savedStateHandle
+                        ?.set(PICKUP_LIST_NEEDS_REFRESH, true)
+                    navController.navigateUp()
+                }
+            )
         }
 
         composable<PathEditScreenDestination>(

--- a/app/src/main/java/com/mtdevelopment/lafromagerie/navigation/CheeseScreens.kt
+++ b/app/src/main/java/com/mtdevelopment/lafromagerie/navigation/CheeseScreens.kt
@@ -49,6 +49,24 @@ data class PathEditScreenDestination(
 )
 
 /**
+ * Navigation destination for the pickup point list (Admin side).
+ *
+ * Registered only in the admin navigation graph; the client one never reaches it.
+ */
+@Serializable
+object PickupPointsScreenDestination
+
+/**
+ * Navigation destination for the pickup point editor (Admin side).
+ *
+ * @property pointId Point to edit, or null to create a new one.
+ */
+@Serializable
+data class PickupPointEditScreenDestination(
+    val pointId: String? = null
+)
+
+/**
  * Navigation destination for the Checkout and Payment screen.
  */
 @Serializable

--- a/core/domain/src/main/java/com/mtdevelopment/core/domain/LogicUtils.kt
+++ b/core/domain/src/main/java/com/mtdevelopment/core/domain/LogicUtils.kt
@@ -161,6 +161,20 @@ fun <T> reorderList(list: List<T>, indices: List<Int?>): List<T> {
 }
 
 /**
+ * Formats a stored `DayOfWeek` name ("MONDAY") into its French display name ("lundi").
+ * Returns null for anything that is not a day, so callers can drop it rather than render
+ * a placeholder.
+ */
+fun frenchDayName(dayOfWeekName: String): String? {
+    return runCatching {
+        java.time.DayOfWeek.valueOf(dayOfWeekName.uppercase()).getDisplayName(
+            java.time.format.TextStyle.FULL,
+            java.util.Locale.FRENCH
+        )
+    }.getOrNull()
+}
+
+/**
  * Formats the delivery day and frequency into a localized French string.
  * Supporting full or short display formats (short format for admin UI).
  */

--- a/core/domain/src/main/java/com/mtdevelopment/core/model/PickupPoint.kt
+++ b/core/domain/src/main/java/com/mtdevelopment/core/model/PickupPoint.kt
@@ -1,0 +1,74 @@
+package com.mtdevelopment.core.model
+
+import com.mtdevelopment.core.domain.toLocalDate
+
+/**
+ * What kind of place an order can be collected at.
+ *
+ * The two kinds are shaped differently on purpose, which is why they are one type with a
+ * discriminator rather than two: the shop recurs (it opens on the same weekdays every
+ * week), a market does not. Markets come round roughly once a month with no usable
+ * weekly rhythm, so each one is entered as its own dated point.
+ */
+enum class PickupPointType {
+    /** The shop itself: recurring opening days, minus explicit closures. */
+    SHOP,
+
+    /** One market on one date, at its own address. */
+    MARKET;
+
+    companion object {
+        /** Reads a stored value, falling back to [SHOP] for anything unknown or absent. */
+        fun fromStoredValue(value: String?): PickupPointType =
+            runCatching { valueOf(value.orEmpty()) }.getOrDefault(SHOP)
+    }
+}
+
+/**
+ * A place and time at which the customer can collect an order.
+ *
+ * Deliberately **not** modelled as a `DeliveryPath`. A path is geocoded, cached in Room and
+ * matched against the customer's address street by street; none of that means anything for
+ * a counter the customer walks up to. Sharing the type would have dragged all of it along.
+ *
+ * @property id Firestore document id. Blank for a point that has never been saved.
+ * @property type Shop or market — decides which of the fields below carry meaning.
+ * @property label Name shown to the customer, e.g. "Marché de Pontarlier".
+ * @property address Postal address, geocoded for the map pin.
+ * @property latitude Geocoded latitude, null while the address has not been resolved.
+ * @property longitude Geocoded longitude, null while the address has not been resolved.
+ * @property timeRange Opening window shown to the customer, e.g. "8h-13h". Displayed only —
+ *   the customer picks a day, never a slot.
+ * @property openingDays [PickupPointType.SHOP] only: `DayOfWeek` names the shop opens on.
+ * @property closedDates [PickupPointType.SHOP] only: `dd/MM/yyyy` dates to skip despite
+ *   falling on an opening day — holidays, and the days the owner is simply away. Without
+ *   these, a recurring shop could not be closed at all.
+ * @property date [PickupPointType.MARKET] only: the single `dd/MM/yyyy` date it happens on.
+ */
+@kotlinx.serialization.Serializable
+data class PickupPoint(
+    val id: String = "",
+    val type: PickupPointType = PickupPointType.SHOP,
+    val label: String = "",
+    val address: String = "",
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val timeRange: String = "",
+    val openingDays: List<String> = emptyList(),
+    val closedDates: List<String> = emptyList(),
+    val date: String? = null
+) {
+
+    /**
+     * Whether this point is complete enough to be worth storing.
+     *
+     * A shop with no opening day and a market with no date are both invisible to the
+     * customer — saving them would silently produce a point nobody can ever order from,
+     * which reads as a bug rather than as an empty configuration.
+     */
+    val canBeSaved: Boolean
+        get() = label.isNotBlank() && address.isNotBlank() && when (type) {
+            PickupPointType.SHOP -> openingDays.isNotEmpty()
+            PickupPointType.MARKET -> date?.toLocalDate() != null
+        }
+}

--- a/core/domain/src/test/java/com/mtdevelopment/core/model/PickupPointTest.kt
+++ b/core/domain/src/test/java/com/mtdevelopment/core/model/PickupPointTest.kt
@@ -1,0 +1,70 @@
+package com.mtdevelopment.core.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PickupPointTest {
+
+    private fun shop() = PickupPoint(
+        id = "shop",
+        type = PickupPointType.SHOP,
+        label = "La Fromagerie",
+        address = "3 Grande Rue, 25300 Pontarlier",
+        timeRange = "9h-12h / 15h-19h",
+        openingDays = listOf("TUESDAY", "THURSDAY", "SATURDAY")
+    )
+
+    private fun market() = PickupPoint(
+        id = "market-1",
+        type = PickupPointType.MARKET,
+        label = "Marché de Pontarlier",
+        address = "Place Saint-Bénigne, 25300 Pontarlier",
+        timeRange = "8h-13h",
+        date = "15/08/2026"
+    )
+
+    @Test
+    fun `a complete shop and a complete market can be saved`() {
+        assertTrue(shop().canBeSaved)
+        assertTrue(market().canBeSaved)
+    }
+
+    @Test
+    fun `a shop with no opening day cannot be saved`() {
+        // It would be stored, then be invisible to every customer — which reads as a bug,
+        // not as an empty configuration.
+        assertFalse(shop().copy(openingDays = emptyList()).canBeSaved)
+    }
+
+    @Test
+    fun `a market with no date, or an unparseable one, cannot be saved`() {
+        assertFalse(market().copy(date = null).canBeSaved)
+        assertFalse(market().copy(date = "").canBeSaved)
+        assertFalse(market().copy(date = "2026-08-15").canBeSaved)
+    }
+
+    @Test
+    fun `a point with no label or no address cannot be saved`() {
+        assertFalse(shop().copy(label = "  ").canBeSaved)
+        assertFalse(shop().copy(address = "").canBeSaved)
+        assertFalse(market().copy(label = "").canBeSaved)
+    }
+
+    @Test
+    fun `opening days are irrelevant to a market, and a date to a shop`() {
+        // Switching type mid-edit leaves the other half of the draft populated; neither
+        // should block saving.
+        assertTrue(market().copy(openingDays = emptyList()).canBeSaved)
+        assertTrue(shop().copy(date = null).canBeSaved)
+    }
+
+    @Test
+    fun `an absent or unknown stored type reads as the shop`() {
+        assertEquals(PickupPointType.SHOP, PickupPointType.fromStoredValue(null))
+        assertEquals(PickupPointType.SHOP, PickupPointType.fromStoredValue(""))
+        assertEquals(PickupPointType.SHOP, PickupPointType.fromStoredValue("DRIVE"))
+        assertEquals(PickupPointType.MARKET, PickupPointType.fromStoredValue("MARKET"))
+    }
+}

--- a/delivery/presentation/src/admin/java/com/mtdevelopment/delivery/presentation/screen/DeliveryOptionScreen.kt
+++ b/delivery/presentation/src/admin/java/com/mtdevelopment/delivery/presentation/screen/DeliveryOptionScreen.kt
@@ -4,11 +4,18 @@ import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Storefront
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -39,6 +46,7 @@ fun DeliveryOptionScreen(
     onPathsChangeHandled: () -> Unit = {},
     navigateToCheckout: () -> Unit = {},
     navigateToPathEdit: (String?) -> Unit = {},
+    navigateToPickupPoints: () -> Unit = {},
     navigateBack: () -> Unit = {}
 ) {
 
@@ -118,6 +126,20 @@ fun DeliveryOptionScreen(
                     }
                 }
             )
+
+            // Pickup points live here rather than on the admin home: this screen is already
+            // the "where and when do I sell" configuration, and the home screen keeps the
+            // three buttons it has.
+            TextButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                onClick = navigateToPickupPoints
+            ) {
+                Icon(Icons.Rounded.Storefront, contentDescription = null)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Points de retrait (boutique et marchés)")
+            }
 
             Spacer(modifier = Modifier.imePadding())
         }

--- a/delivery/presentation/src/admin/java/com/mtdevelopment/delivery/presentation/screen/PickupPointEditScreen.kt
+++ b/delivery/presentation/src/admin/java/com/mtdevelopment/delivery/presentation/screen/PickupPointEditScreen.kt
@@ -1,0 +1,413 @@
+package com.mtdevelopment.delivery.presentation.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Clear
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import com.mtdevelopment.admin.presentation.composable.ProductEditField
+import com.mtdevelopment.admin.presentation.viewmodel.AdminViewModel
+import com.mtdevelopment.core.domain.frenchDayName
+import com.mtdevelopment.core.domain.toLocalDate
+import com.mtdevelopment.core.domain.toStringDate
+import com.mtdevelopment.core.model.PickupPoint
+import com.mtdevelopment.core.model.PickupPointType
+import com.mtdevelopment.core.presentation.composable.AddressAutocompleteTextField
+import com.mtdevelopment.core.presentation.composable.ErrorOverlay
+import com.mtdevelopment.core.presentation.composable.PrimaryButton
+import com.mtdevelopment.core.presentation.composable.RiveAnimation
+import kotlinx.serialization.json.Json
+import org.koin.androidx.compose.koinViewModel
+import java.time.DayOfWeek
+
+/**
+ * Survives configuration changes the same way the path editor's draft does: a half-filled
+ * market date is annoying enough to retype once, infuriating on every rotation.
+ */
+private val PickupPointSaver: Saver<PickupPoint, String> = Saver(
+    save = { Json.encodeToString(PickupPoint.serializer(), it) },
+    restore = { runCatching { Json.decodeFromString(PickupPoint.serializer(), it) }.getOrNull() }
+)
+
+/**
+ * Creates or edits one pickup point.
+ *
+ * The form changes shape with the type, because the two kinds genuinely differ: the shop
+ * recurs on weekdays and needs a way to be closed, a market happens once on one date. Both
+ * halves stay in the draft when the type is switched mid-edit, so nothing typed is lost;
+ * the fields that no longer apply are dropped at the mapping boundary instead.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun PickupPointEditScreen(
+    pointId: String? = null,
+    onSaved: () -> Unit = {}
+) {
+    val viewModel = koinViewModel<AdminViewModel>()
+    val state by viewModel.pickupPointsState.collectAsState()
+    val orderState by viewModel.orderScreenState.collectAsState()
+
+    val focusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
+    val scrollState = rememberScrollState()
+
+    var draft by rememberSaveable(stateSaver = PickupPointSaver) {
+        mutableStateOf(PickupPoint())
+    }
+    var draftInitialised by rememberSaveable { mutableStateOf(false) }
+
+    // Which date picker is open: the market's own date, or a closure being added.
+    var datePickerTarget by remember { mutableStateOf<DatePickerTarget?>(null) }
+
+    LaunchedEffect(Unit) {
+        if (state.points.isEmpty()) viewModel.getAllPickupPoints()
+    }
+
+    // Editing waits for the point to come back from Firestore; creating starts immediately.
+    // Guarded so a later refresh of the list never overwrites edits in progress.
+    LaunchedEffect(state.points, pointId) {
+        if (draftInitialised) return@LaunchedEffect
+        if (pointId == null) {
+            draftInitialised = true
+            return@LaunchedEffect
+        }
+        state.points.find { it.id == pointId }?.let { existing ->
+            draft = existing
+            viewModel.setAddressText(existing.address)
+            draftInitialised = true
+        }
+    }
+
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(scrollState)
+                    .imePadding()
+                    .padding(16.dp)
+            ) {
+                Text(
+                    text = if (pointId == null) {
+                        "Nouveau point de retrait"
+                    } else {
+                        "Modifier le point de retrait"
+                    },
+                    style = MaterialTheme.typography.titleLarge
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    PickupPointType.entries.forEach { entry ->
+                        FilterChip(
+                            selected = draft.type == entry,
+                            onClick = { draft = draft.copy(type = entry) },
+                            label = { Text(entry.frenchLabel()) }
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                ProductEditField(
+                    title = "Nom affiché au client",
+                    value = draft.label,
+                    onValueChange = { draft = draft.copy(label = it) },
+                    isError = draft.label.isBlank(),
+                    imeAction = ImeAction.Next,
+                    placeholder = when (draft.type) {
+                        PickupPointType.SHOP -> "La Fromagerie"
+                        PickupPointType.MARKET -> "Marché de Pontarlier"
+                    }
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                AddressAutocompleteTextField(
+                    label = "Adresse",
+                    searchQuery = orderState.searchQuery,
+                    suggestions = orderState.suggestions,
+                    isLoading = orderState.suggestionsLoading,
+                    showDropdown = orderState.showSuggestions,
+                    focusRequester = focusRequester,
+                    focusManager = focusManager,
+                    onDropDownDismiss = { viewModel.setShowAddressesSuggestions(false) },
+                    onAddressValidated = { validated, suggestion ->
+                        // The suggestion already carries coordinates, so the map pin costs
+                        // no extra geocoding call. They stay null on a hand-typed address:
+                        // the point still works, it simply cannot be mapped.
+                        draft = draft.copy(
+                            address = validated,
+                            latitude = suggestion?.lat,
+                            longitude = suggestion?.long
+                        )
+                        suggestion?.let { viewModel.onSuggestionSelected(it) }
+                    },
+                    onValueChange = {
+                        draft = draft.copy(address = it)
+                        viewModel.setAddressText(it)
+                    },
+                    onClick = { viewModel.setShowAddressesSuggestions(true) }
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                ProductEditField(
+                    title = "Horaires affichés",
+                    value = draft.timeRange,
+                    onValueChange = { draft = draft.copy(timeRange = it) },
+                    imeAction = ImeAction.Done,
+                    placeholder = "8h-13h"
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                when (draft.type) {
+                    PickupPointType.SHOP -> {
+                        Text(
+                            text = "Jours d'ouverture",
+                            style = MaterialTheme.typography.titleMedium.copy(
+                                fontWeight = FontWeight.Bold
+                            )
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            DayOfWeek.entries.forEach { day ->
+                                val isSelected = draft.openingDays.contains(day.name)
+                                FilterChip(
+                                    selected = isSelected,
+                                    onClick = {
+                                        draft = draft.copy(
+                                            openingDays = if (isSelected) {
+                                                draft.openingDays - day.name
+                                            } else {
+                                                draft.openingDays + day.name
+                                            }
+                                        )
+                                    },
+                                    label = { Text(frenchDayName(day.name).orEmpty()) }
+                                )
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(24.dp))
+
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                modifier = Modifier.weight(1f),
+                                text = "Fermetures exceptionnelles",
+                                style = MaterialTheme.typography.titleMedium.copy(
+                                    fontWeight = FontWeight.Bold
+                                )
+                            )
+                            IconButton(onClick = { datePickerTarget = DatePickerTarget.CLOSURE }) {
+                                Icon(
+                                    Icons.Rounded.Add,
+                                    contentDescription = "Ajouter une fermeture"
+                                )
+                            }
+                        }
+                        Text(
+                            text = "Congés, jours fériés : ces dates disparaissent des " +
+                                    "retraits proposés même si elles tombent un jour d'ouverture.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+
+                        draft.closedDates.sortedBy { it.toLocalDate() }.forEach { closed ->
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(modifier = Modifier.weight(1f), text = closed)
+                                IconButton(
+                                    onClick = {
+                                        draft = draft.copy(
+                                            closedDates = draft.closedDates - closed
+                                        )
+                                    }
+                                ) {
+                                    Icon(
+                                        Icons.Rounded.Clear,
+                                        contentDescription = "Retirer cette fermeture"
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    PickupPointType.MARKET -> {
+                        Text(
+                            text = "Date du marché",
+                            style = MaterialTheme.typography.titleMedium.copy(
+                                fontWeight = FontWeight.Bold
+                            )
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        TextButton(
+                            onClick = { datePickerTarget = DatePickerTarget.MARKET_DATE }
+                        ) {
+                            Text(draft.date ?: "Choisir une date")
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                PrimaryButton(
+                    text = "Enregistrer",
+                    enabled = draft.canBeSaved,
+                    onClick = { viewModel.savePickupPoint(draft) { onSaved.invoke() } }
+                )
+
+                if (pointId != null) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    DeletePickupPointButton(
+                        onConfirmed = {
+                            viewModel.deletePickupPoint(draft) { onSaved.invoke() }
+                        }
+                    )
+                }
+
+                Spacer(modifier = Modifier.navigationBarsPadding())
+            }
+
+            RiveAnimation(
+                isLoading = state.isLoading,
+                modifier = Modifier.fillMaxSize(),
+                contentDescription = "Loading animation"
+            )
+
+            ErrorOverlay(
+                isShown = state.error != null,
+                message = state.error,
+                onDismiss = { viewModel.clearPickupPointError() }
+            )
+        }
+    }
+
+    datePickerTarget?.let { target ->
+        PickupDatePickerDialog(
+            onDismiss = { datePickerTarget = null },
+            onDateSelected = { date ->
+                draft = when (target) {
+                    DatePickerTarget.MARKET_DATE -> draft.copy(date = date)
+                    // Adding the same closure twice is a slip, not something worth an
+                    // error dialog: the duplicate is simply dropped.
+                    DatePickerTarget.CLOSURE ->
+                        if (draft.closedDates.contains(date)) {
+                            draft
+                        } else {
+                            draft.copy(closedDates = draft.closedDates + date)
+                        }
+                }
+                datePickerTarget = null
+            }
+        )
+    }
+}
+
+private enum class DatePickerTarget { MARKET_DATE, CLOSURE }
+
+private fun PickupPointType.frenchLabel(): String = when (this) {
+    PickupPointType.SHOP -> "Boutique"
+    PickupPointType.MARKET -> "Marché"
+}
+
+/**
+ * Plain calendar, deliberately not the customer-facing [DatePickerComposable]: that one only
+ * offers the dates a delivery path actually serves, which is the opposite of what the shop
+ * needs when declaring a market or a week of holiday.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PickupDatePickerDialog(
+    onDismiss: () -> Unit,
+    onDateSelected: (String) -> Unit
+) {
+    val pickerState = rememberDatePickerState()
+
+    DatePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                enabled = pickerState.selectedDateMillis != null,
+                onClick = {
+                    // selectedDateMillis is UTC midnight and toStringDate formats in UTC,
+                    // which is the convention every stored date in this app follows.
+                    pickerState.selectedDateMillis?.let { onDateSelected(it.toStringDate()) }
+                }
+            ) {
+                Text("Valider")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Annuler") }
+        }
+    ) {
+        DatePicker(state = pickerState)
+    }
+}
+
+/**
+ * Two-step delete, matching the confirmation pattern the admin dialogs already use: a point
+ * removed by a stray tap would take its market date with it, and there is no undo.
+ */
+@Composable
+private fun DeletePickupPointButton(onConfirmed: () -> Unit) {
+    var confirming by remember { mutableStateOf(false) }
+
+    TextButton(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = { if (confirming) onConfirmed.invoke() else confirming = true }
+    ) {
+        Icon(Icons.Default.Delete, contentDescription = null)
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = if (confirming) "Confirmer la suppression" else "Supprimer ce point",
+            color = MaterialTheme.colorScheme.error
+        )
+    }
+}

--- a/delivery/presentation/src/admin/java/com/mtdevelopment/delivery/presentation/screen/PickupPointsScreen.kt
+++ b/delivery/presentation/src/admin/java/com/mtdevelopment/delivery/presentation/screen/PickupPointsScreen.kt
@@ -1,0 +1,200 @@
+package com.mtdevelopment.delivery.presentation.screen
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material3.Card
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.mtdevelopment.admin.presentation.viewmodel.AdminViewModel
+import com.mtdevelopment.core.domain.frenchDayName
+import com.mtdevelopment.core.model.PickupPoint
+import com.mtdevelopment.core.model.PickupPointType
+import com.mtdevelopment.core.presentation.composable.ErrorOverlay
+import com.mtdevelopment.core.presentation.composable.RiveAnimation
+import org.koin.androidx.compose.koinViewModel
+
+/**
+ * Saved-state key the editor sets on this screen's back-stack entry after a write, so the
+ * list refreshes once instead of re-fetching on every resume. Mirrors
+ * [PATH_LIST_NEEDS_REFRESH]; the two screens either side of the editor are what agree on it.
+ */
+const val PICKUP_LIST_NEEDS_REFRESH = "pickup_list_needs_refresh"
+
+/**
+ * Lists the places an order can be collected: the shop, then every market date.
+ *
+ * Reached from the delivery-path screen rather than from the admin home, so all of the
+ * "where and when do I sell" configuration sits together and the home screen keeps the
+ * three buttons it already has.
+ */
+@Composable
+fun PickupPointsScreen(
+    pointsChanged: Boolean = false,
+    onPointsChangeHandled: () -> Unit = {},
+    navigateToPointEdit: (String?) -> Unit = {}
+) {
+    val viewModel = koinViewModel<AdminViewModel>()
+    val state by viewModel.pickupPointsState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.getAllPickupPoints()
+    }
+
+    LaunchedEffect(pointsChanged) {
+        if (pointsChanged) {
+            viewModel.getAllPickupPoints()
+            onPointsChangeHandled()
+        }
+    }
+
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxSize()) {
+
+            if (state.points.isEmpty() && !state.isLoading && state.error == null) {
+                Text(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .padding(32.dp),
+                    text = "Aucun point de retrait pour l'instant.\n" +
+                            "Ajoutez la boutique ou une date de marché.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    textAlign = TextAlign.Center
+                )
+            }
+
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(items = state.points, key = { it.id }) { point ->
+                    PickupPointCard(
+                        point = point,
+                        onClick = { navigateToPointEdit(point.id) }
+                    )
+                }
+                item { Spacer(modifier = Modifier.height(88.dp)) }
+            }
+
+            FloatingActionButton(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .navigationBarsPadding()
+                    .padding(24.dp),
+                onClick = { navigateToPointEdit(null) }
+            ) {
+                Icon(Icons.Rounded.Add, contentDescription = "Ajouter un point de retrait")
+            }
+
+            RiveAnimation(
+                isLoading = state.isLoading,
+                modifier = Modifier.fillMaxSize(),
+                contentDescription = "Loading animation"
+            )
+
+            ErrorOverlay(
+                isShown = state.error != null,
+                message = state.error,
+                onDismiss = { viewModel.clearPickupPointError() }
+            )
+        }
+    }
+}
+
+@Composable
+private fun PickupPointCard(
+    point: PickupPoint,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = point.label,
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontWeight = FontWeight.Bold
+                    )
+                )
+                Text(
+                    text = when (point.type) {
+                        PickupPointType.SHOP -> "Boutique"
+                        PickupPointType.MARKET -> "Marché"
+                    },
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = point.address,
+                style = MaterialTheme.typography.bodyMedium
+            )
+
+            val schedule = when (point.type) {
+                PickupPointType.SHOP -> point.openingDays
+                    .mapNotNull { frenchDayName(it) }
+                    .joinToString(", ")
+
+                PickupPointType.MARKET -> point.date.orEmpty()
+            }
+
+            if (schedule.isNotBlank() || point.timeRange.isNotBlank()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = listOf(schedule, point.timeRange)
+                        .filter { it.isNotBlank() }
+                        .joinToString(" · "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            // Closures are the only way a recurring shop can be shut, so they are worth
+            // showing on the card rather than hiding one tap away in the editor.
+            if (point.closedDates.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "${point.closedDates.size} fermeture(s) programmée(s)",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
Stacked on lot 1 (#69), which is stacked on lot 0 (#68). The diff here is lot 2 alone.

Adds the `pickup_points` collection and the admin screens that manage it. **Still invisible to customers** — nothing reads these points yet — but the shop can now describe its counter and its market dates, which lot 3 needs before it can offer them.

## Modelling

**Shop and market are one type with a discriminator, not two types.** They differ in shape, not in kind: the shop recurs on weekdays and needs closures, a market happens once on one date. Markets come round about monthly with no usable weekly rhythm, so each one is entered individually — a recurrence model would have expressed the rare case and not the common one.

**`closed_dates` is what makes a recurring shop closable at all.** Without it, "open every Tuesday" admits no holiday, no bank holiday and no week away, and the shop would have to delete and recreate the point to shut for a fortnight.

The address autocomplete already returns coordinates, so the map pin costs **no extra geocoding call**. A hand-typed address simply leaves them null: the point still works, it just cannot be mapped.

## Two invariants carried over from hard-won lessons

**Every mutation bumps `database_update/pickup_timestamp`** — the third such document, paired with the write exactly as delivery paths are. Skipping the bump would leave clients ordering against a stale cache, which here means ordering on a market date that no longer exists.

**A read failure never collapses into an empty list.** "No pickup points" and "we could not read them" look identical on screen and mean opposite things to the shop, so a failure sets an error and leaves the previous list standing.

## UI

Entry point is the delivery-path screen, per your call: that screen is already the "where and when do I sell" configuration, and the admin home keeps the three buttons it has. The list-to-editor refresh reuses the `savedStateHandle` handshake the path editor established.

The editor gets its own plain calendar rather than the customer-facing `DatePickerComposable`, which only offers dates a delivery path actually serves — the opposite of what the shop needs when declaring a market or a holiday.

## Deliberately left to lot 3

The client-side reader, its Room cache, and the "an empty read is a failure, because offline Firestore returns nothing successfully" rule that belongs with it. Building that table now would be a cache with no consumer.

## Verification

- Both flavors compile.
- 17 new unit tests: DTO round-trips both ways, the fields dropped when the type is switched mid-edit, the unknown-type fallback, an empty document, the domain validation, and the use cases (ordering, refusal to store an incomplete point, deletion still allowed on one).
- Full suite at the documented baseline — the same 2 `AdminViewModelTest` failures, no new ones.
- **No Firestore write was performed.** Mappings are proven by unit tests on the DTO.
- Not verified on device: no device was connected. The Koin wiring for the four new use cases is the residual runtime risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)