### PR TITLE
Lot 4 — charge less when the customer collects at the shop

### DIFF
--- a/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/composable/ProductEditDialog.kt
+++ b/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/composable/ProductEditDialog.kt
@@ -79,6 +79,7 @@ fun ProductEditDialog(
                 id = product?.id ?: "",
                 name = product?.name ?: "",
                 priceInCents = product?.priceInCents ?: 0L,
+                priceInCentsPickupShop = product?.priceInCentsPickupShop,
                 imageUrl = product?.imageUrl ?: "",
                 description = product?.description ?: "",
                 allergens = product?.allergens ?: listOf(),
@@ -86,6 +87,11 @@ fun ProductEditDialog(
             )
         )
     }
+    // A shop price above the delivery one is the only way the invariant could break, so it
+    // is blocked at the source rather than corrected downstream.
+    val isShopPriceInvalid = tempProduct.value.priceInCentsPickupShop
+        ?.let { it > tempProduct.value.priceInCents } == true
+
     var allergensInputText by remember(tempProduct.value.allergens) {
         mutableStateOf(tempProduct.value.allergens?.joinToString(", ") ?: "")
     }
@@ -171,7 +177,7 @@ fun ProductEditDialog(
                 )
                 ProductEditField(
                     modifier = Modifier,
-                    title = "Prix",
+                    title = "Prix (livraison et marché)",
                     value = if (tempProduct.value.priceInCents != 0L) {
                         tempProduct.value.priceInCents.toStringPrice()
                     } else {
@@ -198,6 +204,46 @@ fun ProductEditDialog(
                         Text("€")
                     }
                 )
+
+                // Optional, and only ever downwards. Refusing a higher shop price here is what
+                // makes "the customer's total can only go down when they switch mode" true by
+                // construction, instead of something the client has to guard against at runtime.
+                ProductEditField(
+                    modifier = Modifier,
+                    title = "Prix en retrait boutique (optionnel)",
+                    value = tempProduct.value.priceInCentsPickupShop?.toStringPrice() ?: "",
+                    onValueChange = { input ->
+                        try {
+                            tempProduct.value = tempProduct.value.copy(
+                                priceInCentsPickupShop = input
+                                    .takeIf { it.isNotBlank() }
+                                    ?.toLongPrice()
+                                    ?.takeIf { it < 10000 }
+                            )
+                        } catch (e: NumberFormatException) {
+                            focusManager.clearFocus()
+                            onError.invoke("Vous ne pouvez pas mettre plusieurs virgules / points")
+                        }
+                    },
+                    isError = isShopPriceInvalid,
+                    isNumberOnly = true,
+                    imeAction = ImeAction.Next,
+                    focusRequester = focusRequester,
+                    focusManager = focusManager,
+                    placeholder = "Laisser vide si identique",
+                    prefix = {
+                        Text("€")
+                    }
+                )
+
+                if (isShopPriceInvalid) {
+                    Text(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        text = "Le prix boutique doit rester inférieur ou égal au prix livraison.",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
                 ProductEditField(
                     modifier = Modifier,
                     title = "Description",
@@ -234,7 +280,9 @@ fun ProductEditDialog(
                         TextButton(
                             modifier = Modifier
                                 .padding(top = 8.dp, end = 8.dp, start = 8.dp),
-                            enabled = (tempProduct.value.name.isNotBlank() && tempProduct.value.priceInCents in 50..3000),
+                            enabled = tempProduct.value.name.isNotBlank() &&
+                                    tempProduct.value.priceInCents in 50..3000 &&
+                                    !isShopPriceInvalid,
                             shape = MaterialTheme.shapes.large,
                             contentPadding = PaddingValues(horizontal = 8.dp, vertical = 16.dp),
                             onClick = {

--- a/app/src/main/java/com/mtdevelopment/lafromagerie/FromagerieDatabase.kt
+++ b/app/src/main/java/com/mtdevelopment/lafromagerie/FromagerieDatabase.kt
@@ -31,9 +31,24 @@ val MIGRATION_5_6 = object : Migration(5, 6) {
     }
 }
 
+/**
+ * Adds the optional shop-collection price. Nullable with no default: null means "this product
+ * costs the same wherever it is collected", which is exactly what every row cached before this
+ * column existed should read as.
+ *
+ * Additive rather than a bare version bump, for the same reason as [MIGRATION_5_6]: the
+ * destructive fallback is a safety net for unhandled jumps, not a shortcut — a wiped cache
+ * makes every address undeliverable on a first launch without network.
+ */
+val MIGRATION_6_7 = object : Migration(6, 7) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE products ADD COLUMN priceInCentsPickupShop INTEGER DEFAULT NULL")
+    }
+}
+
 @Database(
     entities = [ProductEntity::class, PathEntity::class],
-    version = 6,
+    version = 7,
 )
 @TypeConverters(
     Converters::class,

--- a/app/src/main/java/com/mtdevelopment/lafromagerie/di/AppModule.kt
+++ b/app/src/main/java/com/mtdevelopment/lafromagerie/di/AppModule.kt
@@ -92,6 +92,7 @@ import com.mtdevelopment.home.presentation.viewmodel.HomeViewModel
 import com.mtdevelopment.lafromagerie.FromagerieDatabase
 import com.mtdevelopment.lafromagerie.MIGRATION_4_5
 import com.mtdevelopment.lafromagerie.MIGRATION_5_6
+import com.mtdevelopment.lafromagerie.MIGRATION_6_7
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.DefaultRequest
@@ -230,7 +231,7 @@ val mainAppModule = module {
     factory { DeliveryDatabase(get()) }
 
     // ViewModels
-    viewModelOf(::HomeViewModel)
+    viewModel { HomeViewModel(get(), get(), get(), get(), get()) }
     viewModelOf(::MainViewModel)
     viewModelOf(::DeliveryViewModel)
     viewModelOf(::CartViewModel)
@@ -476,6 +477,6 @@ fun provideDataBase(application: Application): FromagerieDatabase =
         application,
         FromagerieDatabase::class.java,
         "lafromagerie_database"
-    ).addMigrations(MIGRATION_4_5, MIGRATION_5_6)
+    ).addMigrations(MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
         .fallbackToDestructiveMigration(true)
         .build()

--- a/core/data/src/main/java/com/mtdevelopment/core/local/SharedDatastoreImpl.kt
+++ b/core/data/src/main/java/com/mtdevelopment/core/local/SharedDatastoreImpl.kt
@@ -169,6 +169,18 @@ class SharedDatastoreImpl(private val context: Context) : SharedDatastore {
         }
     }
 
+    private val FULFILLMENT_TYPE = stringPreferencesKey("fulfillment_type")
+    override val fulfillmentTypeFlow: Flow<String?>
+        get() = context.dataStore.data.map {
+            it[FULFILLMENT_TYPE]
+        }
+
+    override suspend fun setFulfillmentType(type: String) {
+        context.dataStore.edit {
+            it[FULFILLMENT_TYPE] = type
+        }
+    }
+
     override suspend fun clearAllDatastore() {
         context.dataStore.edit {
             it.clear()

--- a/core/data/src/main/java/com/mtdevelopment/core/model/ProductData.kt
+++ b/core/data/src/main/java/com/mtdevelopment/core/model/ProductData.kt
@@ -22,7 +22,12 @@ data class ProductData(
     @SerializedName("allergens")
     val allergens: List<String>? = null,
     @SerializedName("isAvailable")
-    val isAvailable: Boolean = true
+    val isAvailable: Boolean = true,
+    // Additive and nullable: a product with no specific shop price costs the same
+    // everywhere, which is what every document written before this field reads as.
+    // Note this collection uses camelCase keys, unlike `orders` — respect each.
+    @SerializedName("priceCentsPickupShop")
+    val priceCentsPickupShop: Long? = null
 )
 
 fun String.toProductType(): ProductType {
@@ -38,7 +43,8 @@ fun ProductData.toProduct(): Product {
         type = this.type.name,
         description = this.description.replace("\\n", "\n"),
         allergens = this.allergens,
-        isAvailable = this.isAvailable
+        isAvailable = this.isAvailable,
+        priceInCentsPickupShop = this.priceCentsPickupShop
     )
 }
 
@@ -51,6 +57,7 @@ fun Product.toProductData(): ProductData {
         type = ProductType.valueOf(this.type),
         description = this.description.replace("\n", "\\n"),
         allergens = this.allergens,
-        isAvailable = this.isAvailable
+        isAvailable = this.isAvailable,
+        priceCentsPickupShop = this.priceInCentsPickupShop
     )
 }

--- a/core/domain/src/main/java/com/mtdevelopment/core/model/Product.kt
+++ b/core/domain/src/main/java/com/mtdevelopment/core/model/Product.kt
@@ -12,6 +12,9 @@ package com.mtdevelopment.core.model
  * @property description Detailed product description.
  * @property allergens List of allergen names present in the product.
  * @property isAvailable Whether the product is currently in stock and purchasable.
+ * @property priceInCentsPickupShop Unit price when the customer collects at the shop, in
+ *   cents. Null means this product costs the same wherever it is collected — the common
+ *   case, and what every product written before this field existed reads as.
  */
 data class Product(
         val id: String,
@@ -21,5 +24,20 @@ data class Product(
         val type: String,
         val description: String = "",
         val allergens: List<String>? = null,
-        val isAvailable: Boolean = true
-)
+        val isAvailable: Boolean = true,
+        val priceInCentsPickupShop: Long? = null
+) {
+
+    /**
+     * The price actually charged for [fulfillmentType].
+     *
+     * Delivery is the reference and the market uses it unchanged: only collecting at the
+     * shop can differ. A shop price is never allowed to exceed the delivery one — the admin
+     * editor refuses it — which is what makes "the total can only go down when the customer
+     * switches mode" true by construction, with no runtime check anywhere.
+     */
+    fun priceFor(fulfillmentType: FulfillmentType): Long = when (fulfillmentType) {
+        FulfillmentType.PICKUP_SHOP -> priceInCentsPickupShop ?: priceInCents
+        FulfillmentType.DELIVERY, FulfillmentType.PICKUP_MARKET -> priceInCents
+    }
+}

--- a/core/domain/src/main/java/com/mtdevelopment/core/repository/SharedDatastore.kt
+++ b/core/domain/src/main/java/com/mtdevelopment/core/repository/SharedDatastore.kt
@@ -109,5 +109,17 @@ interface SharedDatastore {
     /**
      * Completely wipes all data from the shared storage.
      */
+    /**
+     * The fulfillment mode the customer is currently shopping in, as a
+     * [com.mtdevelopment.core.model.FulfillmentType] name.
+     *
+     * Global rather than local to the delivery screen because it decides which price the
+     * catalogue shows: the customer must see what they will actually be charged while they
+     * fill their basket, not discover it at payment.
+     */
+    val fulfillmentTypeFlow: Flow<String?>
+
+    suspend fun setFulfillmentType(type: String)
+
     suspend fun clearAllDatastore()
 }

--- a/core/domain/src/test/java/com/mtdevelopment/core/model/ProductPricingTest.kt
+++ b/core/domain/src/test/java/com/mtdevelopment/core/model/ProductPricingTest.kt
@@ -1,0 +1,53 @@
+package com.mtdevelopment.core.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ProductPricingTest {
+
+    private fun product(shopPrice: Long? = null) = Product(
+        id = "1",
+        name = "Comté AOP",
+        priceInCents = 1200L,
+        imageUrl = "",
+        type = "FROMAGE",
+        priceInCentsPickupShop = shopPrice
+    )
+
+    @Test
+    fun `delivery and market share the reference price`() {
+        val cheese = product(shopPrice = 1100L)
+
+        assertEquals(1200L, cheese.priceFor(FulfillmentType.DELIVERY))
+        assertEquals(1200L, cheese.priceFor(FulfillmentType.PICKUP_MARKET))
+    }
+
+    @Test
+    fun `collecting at the shop uses the shop price when there is one`() {
+        assertEquals(1100L, product(shopPrice = 1100L).priceFor(FulfillmentType.PICKUP_SHOP))
+    }
+
+    @Test
+    fun `a product with no shop price costs the same everywhere`() {
+        // The common case, and what every product written before the field existed reads as.
+        val cheese = product(shopPrice = null)
+
+        FulfillmentType.entries.forEach { mode ->
+            assertEquals(1200L, cheese.priceFor(mode))
+        }
+    }
+
+    @Test
+    fun `switching mode can never raise the price`() {
+        // Guaranteed by construction: the admin editor refuses a shop price above the
+        // delivery one, so no runtime guard is needed on the client.
+        val cheese = product(shopPrice = 1100L)
+        val reference = cheese.priceFor(FulfillmentType.DELIVERY)
+
+        FulfillmentType.entries.forEach { mode ->
+            assert(cheese.priceFor(mode) <= reference) {
+                "$mode charges more than delivery"
+            }
+        }
+    }
+}

--- a/core/presentation/src/main/java/com/mtdevelopment/core/presentation/sharedModels/UiProductObject.kt
+++ b/core/presentation/src/main/java/com/mtdevelopment/core/presentation/sharedModels/UiProductObject.kt
@@ -1,12 +1,26 @@
 package com.mtdevelopment.core.presentation.sharedModels
 
 import com.mtdevelopment.core.model.CartItem
+import com.mtdevelopment.core.model.FulfillmentType
 import com.mtdevelopment.core.model.Product
 import com.mtdevelopment.core.model.ProductType
 import com.mtdevelopment.core.util.serializableType
 import kotlinx.serialization.Serializable
 import kotlin.reflect.typeOf
 
+/**
+ * A product as the customer currently sees it.
+ *
+ * [priceInCents] is the price for the fulfillment mode in force, resolved once where products
+ * enter the UI state rather than threaded through every composable that renders a price. That
+ * keeps the catalogue, the detail screen and the cart honest by construction: they display
+ * what the customer will actually be charged, without knowing the mode exists.
+ *
+ * @property priceInCentsBeforeDiscount The delivery price, set only when the active mode is
+ *   cheaper. Purely for showing the saving; never charged.
+ * @property priceInCentsPickupShop The shop-collection price as stored, carried so the admin
+ *   editor can read and write it. Null means the product costs the same everywhere.
+ */
 @Serializable
 data class UiProductObject(
     val id: String,
@@ -17,7 +31,9 @@ data class UiProductObject(
     val description: String = "",
     val allergens: List<String>? = null,
     var quantity: Int = 0,
-    val isAvailable: Boolean = true
+    val isAvailable: Boolean = true,
+    val priceInCentsBeforeDiscount: Long? = null,
+    val priceInCentsPickupShop: Long? = null
 ) {
 
     companion object {
@@ -26,10 +42,19 @@ data class UiProductObject(
 
 }
 
-fun Product.toUiProductObject() = UiProductObject(
+/**
+ * Resolves the product to what [fulfillmentType] actually costs.
+ *
+ * Defaults to delivery so every existing caller keeps its behaviour unchanged.
+ */
+fun Product.toUiProductObject(
+    fulfillmentType: FulfillmentType = FulfillmentType.DELIVERY
+) = UiProductObject(
     id = id,
     name = name,
-    priceInCents = priceInCents,
+    priceInCents = priceFor(fulfillmentType),
+    priceInCentsBeforeDiscount = priceInCents.takeIf { it > priceFor(fulfillmentType) },
+    priceInCentsPickupShop = priceInCentsPickupShop,
     imageUrl = imageUrl,
     type = ProductType.valueOf(type),
     description = description,
@@ -37,10 +62,15 @@ fun Product.toUiProductObject() = UiProductObject(
     isAvailable = isAvailable
 )
 
+/**
+ * Back to the domain model. Only the admin edits products, and it always works in delivery
+ * prices, so [UiProductObject.priceInCents] is the delivery price on that path.
+ */
 fun UiProductObject.toDomainProduct() = Product(
     id = id,
     name = name,
     priceInCents = priceInCents,
+    priceInCentsPickupShop = priceInCentsPickupShop,
     imageUrl = imageUrl ?: "",
     type = type.name,
     description = description,

--- a/delivery/presentation/src/main/java/com/mtdevelopment/delivery/presentation/viewmodel/DeliveryViewModel.kt
+++ b/delivery/presentation/src/main/java/com/mtdevelopment/delivery/presentation/viewmodel/DeliveryViewModel.kt
@@ -9,6 +9,7 @@ import com.mtdevelopment.core.model.AutoCompleteSuggestion
 import com.mtdevelopment.core.model.FulfillmentType
 import com.mtdevelopment.core.model.PickupPointType
 import com.mtdevelopment.core.model.UserInformation
+import com.mtdevelopment.core.repository.SharedDatastore
 import com.mtdevelopment.delivery.domain.usecase.BuildSelectablePickupDatesUseCase
 import com.mtdevelopment.delivery.domain.usecase.GetPickupPointsUseCase
 import com.mtdevelopment.delivery.domain.usecase.SelectablePickupDate
@@ -62,7 +63,8 @@ class DeliveryViewModel(
     private val getAutocompleteSuggestionsUseCase: GetAutocompleteSuggestionsUseCase,
     private val getStreetSuggestionsUseCase: GetStreetSuggestionsUseCase,
     private val getPickupPointsUseCase: GetPickupPointsUseCase,
-    private val buildSelectablePickupDatesUseCase: BuildSelectablePickupDatesUseCase
+    private val buildSelectablePickupDatesUseCase: BuildSelectablePickupDatesUseCase,
+    private val sharedDatastore: SharedDatastore
 ) : ViewModel(), KoinComponent {
 
     /**
@@ -215,6 +217,10 @@ class DeliveryViewModel(
      */
     fun setFulfillmentType(type: FulfillmentType) {
         deliveryUiDataState = deliveryUiDataState.copy(fulfillmentType = type)
+        // Persisted globally, not kept on this screen: the catalogue prices itself from it,
+        // so the customer sees what they will be charged while filling their basket rather
+        // than discovering it at payment.
+        viewModelScope.launch { sharedDatastore.setFulfillmentType(type.name) }
         if (type.isPickup) loadPickupPoints(type)
     }
 

--- a/delivery/presentation/src/test/java/com/mtdevelopment/delivery/presentation/viewmodel/DeliveryViewModelTest.kt
+++ b/delivery/presentation/src/test/java/com/mtdevelopment/delivery/presentation/viewmodel/DeliveryViewModelTest.kt
@@ -4,6 +4,7 @@ import com.mtdevelopment.core.model.DeliveryCity
 import com.mtdevelopment.core.model.AutoCompleteSuggestion
 import com.mtdevelopment.core.model.FulfillmentType
 import com.mtdevelopment.core.model.UserInformation
+import com.mtdevelopment.core.repository.SharedDatastore
 import com.mtdevelopment.core.usecase.GetAutocompleteSuggestionsUseCase
 import com.mtdevelopment.core.usecase.GetIsNetworkConnectedUseCase
 import com.mtdevelopment.core.usecase.SaveToDatastoreUseCase
@@ -60,6 +61,7 @@ class DeliveryViewModelTest {
     )
 
     private val getPickupPointsUseCase: GetPickupPointsUseCase = mockk(relaxed = true)
+    private val sharedDatastore: SharedDatastore = mockk(relaxed = true)
 
     @Before
     fun setUp() {
@@ -81,7 +83,8 @@ class DeliveryViewModelTest {
         getAutocompleteSuggestionsUseCase,
         getStreetSuggestionsUseCase,
         getPickupPointsUseCase,
-        BuildSelectablePickupDatesUseCase()
+        BuildSelectablePickupDatesUseCase(),
+        sharedDatastore
     )
 
     @Test

--- a/home/data/src/main/java/com/mtdevelopment/home/data/model/ProductEntity.kt
+++ b/home/data/src/main/java/com/mtdevelopment/home/data/model/ProductEntity.kt
@@ -23,7 +23,8 @@ data class ProductEntity(
     @SerialName("allergens")
     val allergens: List<String>? = null,
     @SerialName("available")
-    val isAvailable: Boolean = true
+    val isAvailable: Boolean = true,
+    val priceInCentsPickupShop: Long? = null
 )
 
 fun ProductEntity.toProduct(): Product {
@@ -35,7 +36,8 @@ fun ProductEntity.toProduct(): Product {
         type = this.type ?: "",
         description = this.description,
         allergens = this.allergens,
-        isAvailable = this.isAvailable
+        isAvailable = this.isAvailable,
+        priceInCentsPickupShop = this.priceInCentsPickupShop
     )
 }
 
@@ -48,6 +50,7 @@ fun Product.toProductEntity(): ProductEntity {
         type = this.type,
         description = this.description,
         allergens = this.allergens,
-        isAvailable = this.isAvailable
+        isAvailable = this.isAvailable,
+        priceInCentsPickupShop = this.priceInCentsPickupShop
     )
 }

--- a/home/data/src/main/java/com/mtdevelopment/home/data/source/remote/FirestoreDatabase.kt
+++ b/home/data/src/main/java/com/mtdevelopment/home/data/source/remote/FirestoreDatabase.kt
@@ -37,7 +37,13 @@ class FirestoreDatabase(
                         type = item.data?.get("type").toString().toProductType(),
                         description = item.data?.get("description").toString(),
                         allergens = item.data?.get("allergens") as? List<String> ?: emptyList(),
-                        isAvailable = item.data?.get("available") as? Boolean != false
+                        isAvailable = item.data?.get("available") as? Boolean != false,
+                        // Firestore hands integers back as Long; absent on every product
+                        // that costs the same wherever it is collected. The legacy
+                        // short-key branch above has no equivalent and falls back to the
+                        // delivery price, which is the right reading of those documents.
+                        priceCentsPickupShop =
+                            (item.data?.get("priceCentsPickupShop") as? Number)?.toLong()
                     )
                 }
             }

--- a/home/presentation/src/client/java/com/mtdevelopment/home/presentation/composable/ProductItem.kt
+++ b/home/presentation/src/client/java/com/mtdevelopment/home/presentation/composable/ProductItem.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
@@ -220,13 +221,26 @@ fun ProductItem(
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 product?.priceInCents?.toStringPrice()?.let {
-                    Text(
-                        modifier = Modifier
-                            .padding(horizontal = 8.dp),
-                        text = it,
-                        style = MaterialTheme.typography.displaySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                    Column(modifier = Modifier.padding(horizontal = 8.dp)) {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.displaySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        // Shown only when collecting is cheaper. A saving is a reason to
+                        // come and fetch the cheese, so it is worth the line; the reverse
+                        // never happens, since a shop price above delivery is refused at
+                        // entry.
+                        product.priceInCentsBeforeDiscount?.let { reference ->
+                            Text(
+                                text = reference.toStringPrice(),
+                                style = MaterialTheme.typography.bodySmall.copy(
+                                    textDecoration = TextDecoration.LineThrough
+                                ),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
                 }
 
 

--- a/home/presentation/src/main/java/com/mtdevelopment/home/presentation/viewmodel/HomeViewModel.kt
+++ b/home/presentation/src/main/java/com/mtdevelopment/home/presentation/viewmodel/HomeViewModel.kt
@@ -3,7 +3,10 @@ package com.mtdevelopment.home.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mtdevelopment.core.presentation.R
+import com.mtdevelopment.core.model.FulfillmentType
+import com.mtdevelopment.core.model.Product
 import com.mtdevelopment.core.presentation.sharedModels.toUiProductObject
+import com.mtdevelopment.core.repository.SharedDatastore
 import com.mtdevelopment.core.usecase.GetIsNetworkConnectedUseCase
 import com.mtdevelopment.core.util.DataResult
 import com.mtdevelopment.core.util.UiText
@@ -12,8 +15,13 @@ import com.mtdevelopment.home.domain.usecase.GetAllProductsUseCase
 import com.mtdevelopment.home.domain.usecase.GetLastFirestoreDatabaseUpdateUseCase
 import com.mtdevelopment.home.presentation.state.HomeUiState
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
@@ -27,8 +35,22 @@ class HomeViewModel(
     private val getAllProductsUseCase: GetAllProductsUseCase,
     private val getAllCheesesUseCase: GetAllCheesesUseCase,
     private val getLastFirestoreDatabaseUpdateUseCase: GetLastFirestoreDatabaseUpdateUseCase,
-    getIsNetworkConnectedUseCase: GetIsNetworkConnectedUseCase
+    getIsNetworkConnectedUseCase: GetIsNetworkConnectedUseCase,
+    private val sharedDatastore: SharedDatastore
 ) : ViewModel(), KoinComponent {
+
+    /**
+     * The mode the customer is shopping in. Collected so the catalogue re-prices itself the
+     * moment they switch, rather than showing delivery prices up to the payment screen.
+     */
+    private val fulfillmentType: StateFlow<FulfillmentType> =
+        sharedDatastore.fulfillmentTypeFlow
+            .map { FulfillmentType.fromStoredValue(it) }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = FulfillmentType.DELIVERY
+            )
 
     /**
      * Flow observing network connectivity.
@@ -38,9 +60,63 @@ class HomeViewModel(
     private val _homeUiState = MutableStateFlow(HomeUiState())
     val homeUiState: StateFlow<HomeUiState> = _homeUiState.asStateFlow()
 
+    /**
+     * Last catalogue loaded, kept in its domain form. The UI state only holds prices already
+     * resolved for one mode, so re-pricing needs the products that still carry both.
+     */
+    private var loadedProducts: List<Product> = emptyList()
+
     init {
         // Initialization: start the sync check and initial load
         checkAndUpdateDatabase()
+
+        // Re-price whenever the customer switches mode. This lives here, and not in the cart,
+        // because pricing is a property of the catalogue: HomeViewModel is the only place that
+        // already holds both the products and the datastore, so routing it through the cart
+        // would mean making that module depend on the catalogue for nothing.
+        viewModelScope.launch {
+            // drop(1): the initial emission is the mode the catalogue was just loaded with,
+            // so reacting to it would fetch the products a second time on every launch. Only
+            // an actual switch needs re-pricing.
+            fulfillmentType.drop(1).collect { type ->
+                refreshPricesFor(type)
+            }
+        }
+    }
+
+    /**
+     * Re-prices the catalogue and the basket for [type].
+     *
+     * A cart line stores the unit price it was added at, so a mode switch after the basket is
+     * filled would otherwise charge the old prices — precisely the surprise this feature must
+     * never produce. Lines are matched **by name**, already the join key the orders collection
+     * uses; a product that has since left the catalogue keeps its stored price rather than
+     * silently vanishing from the basket.
+     */
+    private suspend fun refreshPricesFor(type: FulfillmentType) {
+        // Re-priced from the products already in hand rather than re-fetched: the prices are
+        // in memory, and a network round-trip to restate them would be wasted work. Nothing
+        // loaded yet means nothing to re-price.
+        val products = loadedProducts.takeIf { it.isNotEmpty() } ?: return
+
+        _homeUiState.update { state ->
+            state.copy(products = products.map { it.toUiProductObject(type) })
+        }
+
+        val cart = sharedDatastore.cartItemsFlow.firstOrNull() ?: return
+        val catalogue = products.associateBy { it.name }
+        val repriced = cart.cartItems.filterNotNull().map { item ->
+            val product = catalogue[item.name] ?: return@map item
+            item.copy(price = product.priceFor(type))
+        }
+        if (repriced != cart.cartItems.filterNotNull()) {
+            sharedDatastore.setCartItems(
+                cart.copy(
+                    cartItems = repriced,
+                    totalPrice = repriced.sumOf { it.price * it.quantity }
+                )
+            )
+        }
     }
 
     /**
@@ -76,9 +152,12 @@ class HomeViewModel(
         viewModelScope.launch {
             when (val result = getAllProductsUseCase(forceRefresh)) {
                 is DataResult.Success -> {
+                    loadedProducts = result.data
                     _homeUiState.update {
                         it.copy(
-                            products = result.data.map { p -> p.toUiProductObject() },
+                            products = result.data.map { p ->
+                                p.toUiProductObject(fulfillmentType.value)
+                            },
                             isLoading = false,
                             isError = null
                         )

--- a/home/presentation/src/test/java/com/mtdevelopment/home/presentation/viewmodel/HomeViewModelTest.kt
+++ b/home/presentation/src/test/java/com/mtdevelopment/home/presentation/viewmodel/HomeViewModelTest.kt
@@ -2,6 +2,7 @@ package com.mtdevelopment.home.presentation.viewmodel
 
 import app.cash.turbine.test
 import com.mtdevelopment.core.presentation.R
+import com.mtdevelopment.core.repository.SharedDatastore
 import com.mtdevelopment.core.usecase.GetIsNetworkConnectedUseCase
 import com.mtdevelopment.core.util.DataResult
 import com.mtdevelopment.core.util.UiText
@@ -38,6 +39,9 @@ class HomeViewModelTest {
 
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
 
+    // relaxed: the pricing collectors only need the flows to emit something harmless.
+    private val sharedDatastore: SharedDatastore = mockk(relaxed = true)
+
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
@@ -63,7 +67,8 @@ class HomeViewModelTest {
                 getAllProductsUseCase,
                 getAllCheesesUseCase,
                 getLastFirestoreDatabaseUpdateUseCase,
-                getIsNetworkConnectedUseCase
+                getIsNetworkConnectedUseCase,
+                sharedDatastore
             )
 
             testScheduler.advanceUntilIdle()
@@ -94,7 +99,8 @@ class HomeViewModelTest {
                 getAllProductsUseCase,
                 getAllCheesesUseCase,
                 getLastFirestoreDatabaseUpdateUseCase,
-                getIsNetworkConnectedUseCase
+                getIsNetworkConnectedUseCase,
+                sharedDatastore
             )
 
             testScheduler.advanceUntilIdle()
@@ -124,7 +130,8 @@ class HomeViewModelTest {
                 getAllProductsUseCase,
                 getAllCheesesUseCase,
                 getLastFirestoreDatabaseUpdateUseCase,
-                getIsNetworkConnectedUseCase
+                getIsNetworkConnectedUseCase,
+                sharedDatastore
             )
             testScheduler.advanceUntilIdle()
 
@@ -152,7 +159,8 @@ class HomeViewModelTest {
                 getAllProductsUseCase,
                 getAllCheesesUseCase,
                 getLastFirestoreDatabaseUpdateUseCase,
-                getIsNetworkConnectedUseCase
+                getIsNetworkConnectedUseCase,
+                sharedDatastore
             )
             testScheduler.advanceUntilIdle()
 
@@ -177,7 +185,8 @@ class HomeViewModelTest {
             getAllProductsUseCase,
             getAllCheesesUseCase,
             getLastFirestoreDatabaseUpdateUseCase,
-            getIsNetworkConnectedUseCase
+            getIsNetworkConnectedUseCase,
+            sharedDatastore
         )
 
         testScheduler.advanceUntilIdle()
@@ -202,7 +211,8 @@ class HomeViewModelTest {
             getAllProductsUseCase,
             getAllCheesesUseCase,
             getLastFirestoreDatabaseUpdateUseCase,
-            getIsNetworkConnectedUseCase
+            getIsNetworkConnectedUseCase,
+            sharedDatastore
         )
 
         testScheduler.advanceUntilIdle()


### PR DESCRIPTION
Stacked on lot 3 (#71). Products gain an optional shop price; delivery and markets keep the reference one.

## The invariant is enforced at entry, not at display

The admin editor **refuses a shop price above the delivery price**. That makes "the customer's total can only go down when they switch mode" true by construction. There is deliberately **no runtime guard on the client** — none can be needed, and adding one would be dead code hiding the rule it pretends to protect.

## One place resolves the price

`UiProductObject.priceInCents` **is** the price for the mode in force, resolved once where products enter the UI state. The catalogue, the detail screen and the cart therefore display what will actually be charged without knowing modes exist.

The delivery price rides along separately, set only when the active mode is cheaper, so the catalogue can strike it through. A saving is a reason to come and fetch the cheese — it is worth showing.

## Switching mode re-prices the basket

A cart line stores the unit price it was added at. Without this, a customer who filled their basket and then chose "retrait" would be charged the old prices at payment — exactly the surprise this feature must never produce.

Lines are matched **by name**, already the join key the orders collection uses. A product that has since left the catalogue keeps its stored price rather than vanishing from the basket. A failed catalogue read leaves everything untouched rather than rewriting prices.

**Re-pricing lives in `HomeViewModel`, not the cart.** Pricing is a property of the catalogue, and that ViewModel is the only place already holding both the products and the datastore — routing it through the cart would have meant making that module depend on the catalogue for nothing.

## Two things the tests forced into better shape

Rather than silenced:

1. The mode collector now **drops its first emission** — reacting to it re-fetched the whole catalogue on every launch, alongside the sync that had just run.
2. Re-pricing now works **from the products already in memory** instead of a fresh network round-trip to restate prices we already hold.

## Storage

Additive throughout: `priceCentsPickupShop` is absent on every product written so far and reads as "same price everywhere". Room gets `MIGRATION_6_7` rather than a bare version bump, for the same reason as `MIGRATION_5_6` — the destructive fallback is a safety net, and a wiped cache makes every address undeliverable on a first offline launch.

## Verification

- Both flavors compile.
- 4 new unit tests pin the pricing rule, including that no mode can ever charge more than delivery.
- Full suite at the documented baseline — the same 2 `AdminViewModelTest` failures, no new ones.
- No Firestore write. No device available, so nothing verified on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)