### PR TITLE
Lot 5 — let the customer pay when they come and collect

### DIFF
--- a/admin/data/src/main/java/com/mtdevelopment/admin/data/repository/FirebaseAdminRepositoryImpl.kt
+++ b/admin/data/src/main/java/com/mtdevelopment/admin/data/repository/FirebaseAdminRepositoryImpl.kt
@@ -332,6 +332,10 @@ class FirebaseAdminRepositoryImpl(
     /**
      * Updates a preparation status in the database.
      */
+    override suspend fun updateOrderStatus(orderId: String, status: OrderStatus): Result<Unit> {
+        return firestore.updateOrderStatus(orderId, status)
+    }
+
     override suspend fun updatePreparationStatus(status: PreparationStatus): Result<Unit> {
         return firestore.updatePreparationStatus(status.toData())
     }

--- a/admin/data/src/main/java/com/mtdevelopment/admin/data/source/FirestoreAdminDatasource.kt
+++ b/admin/data/src/main/java/com/mtdevelopment/admin/data/source/FirestoreAdminDatasource.kt
@@ -325,6 +325,25 @@ class FirestoreAdminDatasource(
             }
     }
 
+    /**
+     * Moves one order to [status].
+     *
+     * Only the status field is written. The rest of the document belongs to the customer's
+     * app, and a full `set` from here would overwrite fields this build may not even know
+     * about — the same reason the client uses a targeted update.
+     */
+    suspend fun updateOrderStatus(orderId: String, status: OrderStatus): Result<Unit> {
+        return try {
+            firestore.collection("orders")
+                .document(orderId)
+                .update("status", status.name)
+                .await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     // Preparation Status Management
     ///////////////////////////////////////////////////////////////////////////

--- a/admin/domain/src/main/java/com/mtdevelopment/admin/domain/di/adminModule.kt
+++ b/admin/domain/src/main/java/com/mtdevelopment/admin/domain/di/adminModule.kt
@@ -6,7 +6,9 @@ import com.mtdevelopment.admin.domain.usecase.AddNewProductUseCase
 import com.mtdevelopment.admin.domain.usecase.DeletePathUseCase
 import com.mtdevelopment.admin.domain.usecase.DeletePickupPointUseCase
 import com.mtdevelopment.admin.domain.usecase.DeleteProductUseCase
+import com.mtdevelopment.admin.domain.usecase.CancelStaleOnSiteOrdersUseCase
 import com.mtdevelopment.admin.domain.usecase.GetAllPickupPointsUseCase
+import com.mtdevelopment.admin.domain.usecase.MarkOrderPaidOnSiteUseCase
 import com.mtdevelopment.admin.domain.usecase.UpdatePickupPointUseCase
 import com.mtdevelopment.admin.domain.usecase.DetermineNextDeliveryStopUseCase
 import com.mtdevelopment.admin.domain.usecase.GetAllOrdersUseCase
@@ -42,6 +44,8 @@ val adminDomainModule = module {
     factory { DeletePickupPointUseCase(get()) }
 
     factory { GetAllOrdersUseCase(get()) }
+    factory { MarkOrderPaidOnSiteUseCase(get()) }
+    factory { CancelStaleOnSiteOrdersUseCase(get()) }
 
     factory { UpdateShouldShowBatterieOptimizationUseCase(get()) }
     factory { GetOptimizedDeliveryUseCase(get(), get()) }

--- a/admin/domain/src/main/java/com/mtdevelopment/admin/domain/repository/FirebaseAdminRepository.kt
+++ b/admin/domain/src/main/java/com/mtdevelopment/admin/domain/repository/FirebaseAdminRepository.kt
@@ -2,6 +2,7 @@ package com.mtdevelopment.admin.domain.repository
 
 import com.mtdevelopment.core.model.DeliveryPath
 import com.mtdevelopment.core.model.Order
+import com.mtdevelopment.core.model.OrderStatus
 import com.mtdevelopment.core.model.PickupPoint
 import com.mtdevelopment.core.model.PreparationStatus
 import com.mtdevelopment.core.model.Product
@@ -107,6 +108,12 @@ interface FirebaseAdminRepository {
      * @param onSuccess Callback invoked with the list of orders, or null if an error occurs.
      */
     suspend fun getAllOrders(onSuccess: (List<Order>?) -> Unit)
+
+    /**
+     * Moves one order to a new status.
+     * @return Result indicating success or failure.
+     */
+    suspend fun updateOrderStatus(orderId: String, status: OrderStatus): Result<Unit>
 
     /**
      * Retrieves all possible preparation statuses from the database.

--- a/admin/domain/src/main/java/com/mtdevelopment/admin/domain/usecase/OnSitePaymentUseCases.kt
+++ b/admin/domain/src/main/java/com/mtdevelopment/admin/domain/usecase/OnSitePaymentUseCases.kt
@@ -1,0 +1,72 @@
+package com.mtdevelopment.admin.domain.usecase
+
+import com.mtdevelopment.admin.domain.repository.FirebaseAdminRepository
+import com.mtdevelopment.core.domain.toLocalDate
+import com.mtdevelopment.core.model.Order
+import com.mtdevelopment.core.model.OrderStatus
+import com.mtdevelopment.core.model.PaymentMode
+import java.time.LocalDate
+
+/** How long an uncollected, unpaid order is kept before it is written off. */
+const val ON_SITE_ORDER_GRACE_DAYS = 3L
+
+/**
+ * Records that the shop took the money for an order paid on collection.
+ *
+ * Refuses anything that was paid online: those orders are settled by the payment chain, and
+ * a manual "encaissé" on one would paper over whatever went wrong there instead of
+ * surfacing it.
+ */
+class MarkOrderPaidOnSiteUseCase(
+    private val firebaseAdminRepository: FirebaseAdminRepository
+) {
+    suspend operator fun invoke(order: Order): Result<Unit> {
+        if (order.paymentMode != PaymentMode.ON_SITE) {
+            return Result.failure(
+                IllegalArgumentException("Cette commande n'est pas à encaisser sur place")
+            )
+        }
+        return firebaseAdminRepository.updateOrderStatus(order.id, OrderStatus.PAID)
+    }
+}
+
+/**
+ * Writes off orders that were to be paid on collection and never were.
+ *
+ * ⚠️ Strictly limited to [PaymentMode.ON_SITE]. An online order stuck in PENDING means a
+ * payment in flight or a finalization that failed — possibly with the customer already
+ * charged. Cancelling those automatically would erase the only trace of it, so they are
+ * left alone deliberately, to be investigated.
+ *
+ * Runs from the admin app rather than a scheduled backend job: it therefore only sweeps
+ * when the shop opens its order list, which is enough for a write-off with no deadline of
+ * its own. Moving it to a Cloud Function would make it run unattended — an open decision
+ * in the spec, not an oversight.
+ */
+class CancelStaleOnSiteOrdersUseCase(
+    private val firebaseAdminRepository: FirebaseAdminRepository
+) {
+    /**
+     * @param today Injected so the grace period is testable.
+     * @return the ids written off.
+     */
+    suspend operator fun invoke(
+        orders: List<Order>,
+        today: LocalDate = LocalDate.now()
+    ): List<String> {
+        val cutoff = today.minusDays(ON_SITE_ORDER_GRACE_DAYS)
+
+        return orders
+            .filter { it.paymentMode == PaymentMode.ON_SITE && it.status == OrderStatus.PENDING }
+            // An unparseable date is left alone rather than guessed at: cancelling an order
+            // because its date could not be read would be the worst possible reading of it.
+            .filter { order -> order.deliveryDate.toLocalDate()?.isBefore(cutoff) == true }
+            .mapNotNull { order ->
+                order.id.takeIf {
+                    firebaseAdminRepository
+                        .updateOrderStatus(order.id, OrderStatus.CANCELED)
+                        .isSuccess
+                }
+            }
+    }
+}

--- a/admin/domain/src/test/java/com/mtdevelopment/admin/domain/usecase/OnSitePaymentUseCasesTest.kt
+++ b/admin/domain/src/test/java/com/mtdevelopment/admin/domain/usecase/OnSitePaymentUseCasesTest.kt
@@ -1,0 +1,128 @@
+package com.mtdevelopment.admin.domain.usecase
+
+import com.mtdevelopment.admin.domain.repository.FirebaseAdminRepository
+import com.mtdevelopment.core.model.Order
+import com.mtdevelopment.core.model.OrderStatus
+import com.mtdevelopment.core.model.PaymentMode
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+
+class OnSitePaymentUseCasesTest {
+
+    private val repository: FirebaseAdminRepository = mockk()
+
+    // A Wednesday; the grace period reaches back to 07/08/2026.
+    private val today: LocalDate = LocalDate.of(2026, 8, 10)
+
+    @Before
+    fun setUp() {
+        coEvery { repository.updateOrderStatus(any(), any()) } returns Result.success(Unit)
+    }
+
+    private fun order(
+        id: String,
+        deliveryDate: String,
+        paymentMode: PaymentMode = PaymentMode.ON_SITE,
+        status: OrderStatus = OrderStatus.PENDING
+    ) = Order(
+        id = id,
+        customerName = "Jean Dupont",
+        customerAddress = "",
+        customerBillingAddress = "",
+        deliveryDate = deliveryDate,
+        orderDate = "01/08/2026",
+        products = mapOf("Comté AOP" to 1),
+        status = status,
+        note = null,
+        paymentMode = paymentMode
+    )
+
+    @Test
+    fun `marking paid on site moves the order to PAID`() = runTest {
+        val result = MarkOrderPaidOnSiteUseCase(repository).invoke(order("o1", "10/08/2026"))
+
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 1) { repository.updateOrderStatus("o1", OrderStatus.PAID) }
+    }
+
+    @Test
+    fun `an online order cannot be marked paid by hand`() = runTest {
+        // Settling one manually would paper over whatever went wrong in the payment chain.
+        val result = MarkOrderPaidOnSiteUseCase(repository)
+            .invoke(order("o1", "10/08/2026", paymentMode = PaymentMode.ONLINE))
+
+        assertTrue(result.isFailure)
+        coVerify(exactly = 0) { repository.updateOrderStatus(any(), any()) }
+    }
+
+    @Test
+    fun `an unpaid on-site order older than the grace period is written off`() = runTest {
+        val cancelled = CancelStaleOnSiteOrdersUseCase(repository)
+            .invoke(listOf(order("o1", "05/08/2026")), today)
+
+        assertEquals(listOf("o1"), cancelled)
+        coVerify(exactly = 1) { repository.updateOrderStatus("o1", OrderStatus.CANCELED) }
+    }
+
+    @Test
+    fun `an order still inside the grace period is left alone`() = runTest {
+        val cancelled = CancelStaleOnSiteOrdersUseCase(repository)
+            .invoke(listOf(order("o1", "08/08/2026"), order("o2", "10/08/2026")), today)
+
+        assertTrue(cancelled.isEmpty())
+        coVerify(exactly = 0) { repository.updateOrderStatus(any(), any()) }
+    }
+
+    @Test
+    fun `an online order stuck in PENDING is never written off`() = runTest {
+        // It may mean the customer was charged and finalization failed. Cancelling it would
+        // erase the only trace of that; it must be investigated instead.
+        val cancelled = CancelStaleOnSiteOrdersUseCase(repository).invoke(
+            listOf(order("o1", "01/08/2026", paymentMode = PaymentMode.ONLINE)),
+            today
+        )
+
+        assertTrue(cancelled.isEmpty())
+        coVerify(exactly = 0) { repository.updateOrderStatus(any(), any()) }
+    }
+
+    @Test
+    fun `an order already paid or cancelled is left alone`() = runTest {
+        val cancelled = CancelStaleOnSiteOrdersUseCase(repository).invoke(
+            listOf(
+                order("o1", "01/08/2026", status = OrderStatus.PAID),
+                order("o2", "01/08/2026", status = OrderStatus.CANCELED)
+            ),
+            today
+        )
+
+        assertTrue(cancelled.isEmpty())
+    }
+
+    @Test
+    fun `an unreadable date is left alone rather than guessed at`() = runTest {
+        val cancelled = CancelStaleOnSiteOrdersUseCase(repository)
+            .invoke(listOf(order("o1", "2026-08-01")), today)
+
+        assertTrue(cancelled.isEmpty())
+        coVerify(exactly = 0) { repository.updateOrderStatus(any(), any()) }
+    }
+
+    @Test
+    fun `a failed write is not reported as a cancellation`() = runTest {
+        coEvery { repository.updateOrderStatus(any(), any()) } returns
+                Result.failure(RuntimeException("offline"))
+
+        val cancelled = CancelStaleOnSiteOrdersUseCase(repository)
+            .invoke(listOf(order("o1", "01/08/2026")), today)
+
+        assertTrue(cancelled.isEmpty())
+    }
+}

--- a/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/di/adminModule.kt
+++ b/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/di/adminModule.kt
@@ -32,6 +32,9 @@ val adminPresentationModule = module {
             get(),
             get(),
             get(),
+            // On-site payment: mark paid, sweep stale unpaid orders.
+            get(),
+            get(),
         )
     }
 }

--- a/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/screen/OrderPreparationScreen.kt
+++ b/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/screen/OrderPreparationScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -31,6 +32,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -48,6 +50,8 @@ import com.mtdevelopment.admin.presentation.viewmodel.AdminViewModel
 import com.mtdevelopment.core.domain.toLocalDate
 import com.mtdevelopment.core.domain.toTimeStamp
 import com.mtdevelopment.core.model.Order
+import com.mtdevelopment.core.model.OrderStatus
+import com.mtdevelopment.core.model.PaymentMode
 import com.mtdevelopment.core.model.PreparationGroup
 import com.mtdevelopment.core.model.PreparationStatus
 import com.mtdevelopment.core.model.preparationGroup
@@ -75,7 +79,8 @@ fun OrderPreparationScreen() {
     OrderPreparationList(
         orders = state.value.orders,
         preparationStatuses = state.value.preparationStatuses,
-        onUpdateStatus = { viewModel.updatePreparationStatus(it) }
+        onUpdateStatus = { viewModel.updatePreparationStatus(it) },
+        onMarkPaidOnSite = { viewModel.markOrderPaidOnSite(it) }
     )
 
     // Loading and Error overlays
@@ -100,7 +105,8 @@ fun OrderPreparationScreen() {
 fun OrderPreparationList(
     orders: List<Order>,
     preparationStatuses: List<PreparationStatus>,
-    onUpdateStatus: (PreparationStatus) -> Unit
+    onUpdateStatus: (PreparationStatus) -> Unit,
+    onMarkPaidOnSite: (Order) -> Unit = {}
 ) {
     // Batches, newest first. Grouping on the date alone would merge a tournée, the shop
     // pickups and a market of the same day into one aggregate, leaving no way to tell what
@@ -204,7 +210,8 @@ fun OrderPreparationList(
                         group = group,
                         isPastDate = isPastDate,
                         preparationStatuses = preparationStatuses,
-                        onUpdateStatus = onUpdateStatus
+                        onUpdateStatus = onUpdateStatus,
+                        onMarkPaidOnSite = onMarkPaidOnSite
                     )
                 }
             }
@@ -226,7 +233,8 @@ fun OrderPreparationListItem(
     group: PreparationGroup,
     isPastDate: Boolean,
     preparationStatuses: List<PreparationStatus>,
-    onUpdateStatus: (PreparationStatus) -> Unit
+    onUpdateStatus: (PreparationStatus) -> Unit,
+    onMarkPaidOnSite: (Order) -> Unit = {}
 ) {
 
     // Map each order to its products for this delivery date
@@ -383,6 +391,30 @@ fun OrderPreparationListItem(
                                                 ),
                                                 color = MaterialTheme.colorScheme.secondary
                                             )
+                                        }
+
+                                        // Money owed at the counter. Shown only for the
+                                        // orders that carry it, so a delivery round is never
+                                        // cluttered with a button that cannot apply.
+                                        if (order.paymentMode == PaymentMode.ON_SITE) {
+                                            Spacer(modifier = Modifier.height(4.dp))
+                                            if (order.status == OrderStatus.PAID) {
+                                                Text(
+                                                    text = "Encaissé",
+                                                    style = MaterialTheme.typography.labelMedium,
+                                                    color = MaterialTheme.colorScheme.primary
+                                                )
+                                            } else {
+                                                TextButton(
+                                                    contentPadding = PaddingValues(0.dp),
+                                                    onClick = { onMarkPaidOnSite(order) }
+                                                ) {
+                                                    Text(
+                                                        text = "À encaisser • marquer payé",
+                                                        style = MaterialTheme.typography.labelMedium
+                                                    )
+                                                }
+                                            }
                                         }
 
                                         // Highlighted handwritten-style custom instruction/comment note

--- a/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/viewmodel/AdminViewModel.kt
+++ b/admin/presentation/src/main/java/com/mtdevelopment/admin/presentation/viewmodel/AdminViewModel.kt
@@ -14,6 +14,8 @@ import com.mtdevelopment.admin.domain.usecase.GetCurrentLocationOnceUseCase
 import com.mtdevelopment.admin.domain.usecase.GetIsInTrackingModeUseCase
 import com.mtdevelopment.admin.domain.usecase.GetOptimizedDeliveryUseCase
 import com.mtdevelopment.admin.domain.usecase.AddNewPickupPointUseCase
+import com.mtdevelopment.admin.domain.usecase.CancelStaleOnSiteOrdersUseCase
+import com.mtdevelopment.admin.domain.usecase.MarkOrderPaidOnSiteUseCase
 import com.mtdevelopment.admin.domain.usecase.DeletePickupPointUseCase
 import com.mtdevelopment.admin.domain.usecase.GetAllPickupPointsUseCase
 import com.mtdevelopment.admin.domain.usecase.GetPreparationStatusesUseCase
@@ -31,6 +33,7 @@ import com.mtdevelopment.core.model.AutoCompleteSuggestion
 import com.mtdevelopment.core.model.DeliveryPath
 import com.mtdevelopment.core.model.PickupPoint
 import com.mtdevelopment.core.model.Order
+import com.mtdevelopment.core.model.OrderStatus
 import com.mtdevelopment.core.model.PreparationStatus
 import com.mtdevelopment.core.presentation.sharedModels.UiProductObject
 import com.mtdevelopment.core.presentation.sharedModels.toDomainProduct
@@ -75,7 +78,9 @@ class AdminViewModel(
     private val getAllPickupPointsUseCase: GetAllPickupPointsUseCase,
     private val addNewPickupPointUseCase: AddNewPickupPointUseCase,
     private val updatePickupPointUseCase: UpdatePickupPointUseCase,
-    private val deletePickupPointUseCase: DeletePickupPointUseCase
+    private val deletePickupPointUseCase: DeletePickupPointUseCase,
+    private val markOrderPaidOnSiteUseCase: MarkOrderPaidOnSiteUseCase,
+    private val cancelStaleOnSiteOrdersUseCase: CancelStaleOnSiteOrdersUseCase
 ) : ViewModel(), KoinComponent {
 
     ///////////////////////////////////////////////////////////////////////////
@@ -384,6 +389,18 @@ class AdminViewModel(
                         isLoading = false
                     )
                 }
+                // Write off orders that were to be paid on collection and never were. Done
+                // here because there is no scheduled backend job: the sweep runs whenever
+                // the shop opens its order list, which is enough for a write-off that has
+                // no deadline of its own.
+                viewModelScope.launch {
+                    val cancelled = cancelStaleOnSiteOrdersUseCase.invoke(ordersList.orEmpty())
+                    if (cancelled.isNotEmpty()) {
+                        _orderScreenState.update { state ->
+                            state.copy(orders = state.orders.filterNot { it.id in cancelled })
+                        }
+                    }
+                }
             })
             getPreparationStatusesUseCase.invoke(onSuccess = { statusesList ->
                 _orderScreenState.update { state ->
@@ -400,6 +417,33 @@ class AdminViewModel(
         viewModelScope.launch {
             _orderScreenState.update { state ->
                 state.copy(orders = state.orders + order)
+            }
+        }
+    }
+
+    /**
+     * Records that an order to be paid on collection has been paid.
+     *
+     * Optimistic, like the preparation ticks: the shop is standing in front of the customer
+     * and should not wait on a round-trip. A failed write is surfaced and the row reverts.
+     */
+    fun markOrderPaidOnSite(order: Order) {
+        val previous = _orderScreenState.value.orders
+        _orderScreenState.update { state ->
+            state.copy(
+                orders = state.orders.map {
+                    if (it.id == order.id) it.copy(status = OrderStatus.PAID) else it
+                }
+            )
+        }
+        viewModelScope.launch {
+            markOrderPaidOnSiteUseCase.invoke(order).onFailure {
+                _orderScreenState.update { state ->
+                    state.copy(
+                        orders = previous,
+                        error = "L'encaissement n'a pas pu être enregistré."
+                    )
+                }
             }
         }
     }

--- a/admin/presentation/src/test/java/com/mtdevelopment/admin/presentation/viewmodel/AdminViewModelTest.kt
+++ b/admin/presentation/src/test/java/com/mtdevelopment/admin/presentation/viewmodel/AdminViewModelTest.kt
@@ -10,7 +10,9 @@ import com.mtdevelopment.admin.domain.usecase.GetCurrentLocationOnceUseCase
 import com.mtdevelopment.admin.domain.usecase.GetIsInTrackingModeUseCase
 import com.mtdevelopment.admin.domain.usecase.GetOptimizedDeliveryUseCase
 import com.mtdevelopment.admin.domain.usecase.AddNewPickupPointUseCase
+import com.mtdevelopment.admin.domain.usecase.CancelStaleOnSiteOrdersUseCase
 import com.mtdevelopment.admin.domain.usecase.DeletePickupPointUseCase
+import com.mtdevelopment.admin.domain.usecase.MarkOrderPaidOnSiteUseCase
 import com.mtdevelopment.admin.domain.usecase.GetAllPickupPointsUseCase
 import com.mtdevelopment.admin.domain.usecase.GetPreparationStatusesUseCase
 import com.mtdevelopment.admin.domain.usecase.UpdatePickupPointUseCase
@@ -78,6 +80,9 @@ class AdminViewModelTest {
     private val addNewPickupPointUseCase: AddNewPickupPointUseCase = mockk(relaxed = true)
     private val updatePickupPointUseCase: UpdatePickupPointUseCase = mockk(relaxed = true)
     private val deletePickupPointUseCase: DeletePickupPointUseCase = mockk(relaxed = true)
+    private val markOrderPaidOnSiteUseCase: MarkOrderPaidOnSiteUseCase = mockk(relaxed = true)
+    private val cancelStaleOnSiteOrdersUseCase: CancelStaleOnSiteOrdersUseCase =
+        mockk(relaxed = true)
 
     @Before
     fun setUp() {
@@ -113,7 +118,9 @@ class AdminViewModelTest {
         getAllPickupPointsUseCase,
         addNewPickupPointUseCase,
         updatePickupPointUseCase,
-        deletePickupPointUseCase
+        deletePickupPointUseCase,
+        markOrderPaidOnSiteUseCase,
+        cancelStaleOnSiteOrdersUseCase
     )
 
     private fun product(imageUrl: String?) = UiProductObject(

--- a/checkout/presentation/src/main/java/com/mtdevelopment/checkout/presentation/screen/CheckoutScreen.kt
+++ b/checkout/presentation/src/main/java/com/mtdevelopment/checkout/presentation/screen/CheckoutScreen.kt
@@ -448,6 +448,26 @@ fun CheckoutScreen(
                 }
             )
 
+            /**
+             * Pay on collection. Offered only for a collected order: there is nobody to hand
+             * cash to on a delivery round, and offering it there would create orders the shop
+             * can never settle.
+             */
+            if (uiData.value.fulfillmentType.isPickup) {
+                PrimaryButton(
+                    modifier = Modifier
+                        .testTag("payOnSiteButton")
+                        .fillMaxWidth()
+                        .padding(start = 32.dp, end = 32.dp, bottom = 16.dp),
+                    text = "Payer sur place au retrait",
+                    trailingIcon = null,
+                    enabled = isEmailValid,
+                    // Navigation is already driven by isPaymentSuccess above, which the
+                    // ViewModel raises once the order is written.
+                    onClick = { checkoutViewModel.placeOrderToPayOnSite { } }
+                )
+            }
+
             // Debug tool
             if (BuildConfig.DEBUG) {
                 Button(

--- a/checkout/presentation/src/main/java/com/mtdevelopment/checkout/presentation/viewmodel/CheckoutViewModel.kt
+++ b/checkout/presentation/src/main/java/com/mtdevelopment/checkout/presentation/viewmodel/CheckoutViewModel.kt
@@ -42,6 +42,7 @@ import com.mtdevelopment.core.domain.toStringDate
 import com.mtdevelopment.core.model.Order
 import com.mtdevelopment.core.model.FulfillmentType
 import com.mtdevelopment.core.model.OrderStatus
+import com.mtdevelopment.core.model.PaymentMode
 import com.mtdevelopment.core.repository.SharedDatastore
 import com.mtdevelopment.core.usecase.ClearCartUseCase
 import com.mtdevelopment.core.usecase.GetIsNetworkConnectedUseCase
@@ -456,7 +457,10 @@ class CheckoutViewModel(
      * This is done BEFORE payment to ensure the order intent is captured.
      * Status is 'PENDING' until payment succeeds.
      */
-    fun createOrder(isSuccess: (Boolean) -> Unit) {
+    fun createOrder(
+        paymentMode: PaymentMode = PaymentMode.ONLINE,
+        isSuccess: (Boolean) -> Unit
+    ) {
         val cleanName =
             _paymentScreenState.value.buyerName?.trim()?.replace(" ", "_")
                 ?.lowercase(Locale.getDefault())
@@ -494,6 +498,7 @@ class CheckoutViewModel(
                         // purchase. Payment stays ONLINE here — paying on collection is a
                         // separate chain that does not exist yet.
                         fulfillmentType = _paymentScreenState.value.fulfillmentType,
+                        paymentMode = paymentMode,
                         customerPhone = _paymentScreenState.value.buyerPhone,
                         pickupPointId = _paymentScreenState.value.pickupPointId,
                         pickupLabel = _paymentScreenState.value.pickupLabel,
@@ -502,6 +507,36 @@ class CheckoutViewModel(
                     )
                 )
             )
+        }
+    }
+
+    /**
+     * Places an order the customer will pay for when they collect it.
+     *
+     * Deliberately short: no SumUp session, no Google Pay sheet, and no finalization worker,
+     * because there is no payment in flight to reconcile. The order stays PENDING — which is
+     * unambiguous only because [PaymentMode.ON_SITE] rides alongside it; a PENDING online
+     * order means something very different and must never be confused with this one.
+     *
+     * The cart is cleared and the day-of reminder scheduled exactly as a paid order would,
+     * since from the customer's point of view the order is placed either way.
+     */
+    fun placeOrderToPayOnSite(onResult: (Boolean) -> Unit) {
+        createOrder(paymentMode = PaymentMode.ON_SITE) { created ->
+            if (!created) {
+                setPaymentError(
+                    "Une erreur est survenue lors de la création de la commande.\n" +
+                            "Merci de réessayer ultérieurement."
+                )
+                onResult.invoke(false)
+                return@createOrder
+            }
+            viewModelScope.launch {
+                _paymentScreenState.value.orderId?.let { scheduleOrderReminderUseCase.invoke(it) }
+                clearCartUseCase.invoke()
+                _paymentScreenState.update { it.copy(isPaymentSuccess = true) }
+                onResult.invoke(true)
+            }
         }
     }
 


### PR DESCRIPTION
Stacked on lot 4 (#73). The last lot of the spec.

Offered **only for a collected order**. There is nobody to hand cash to on a delivery round, and offering it there would create orders the shop could never settle.

## The order

Written `PENDING` with `payment_mode = ON_SITE`, and nothing else happens: no SumUp session, no Google Pay sheet, no finalization worker — there is no payment in flight to reconcile.

That `PENDING` is unambiguous **only because the payment mode rides alongside it**, which is exactly why lot 1 made it a field rather than a status. The cart is cleared and the day-of reminder scheduled as for any other order, since from the customer's side the order is placed either way.

## The admin could not write orders at all

`addOrder` only ever touched local UI state, so this adds a targeted status update. **Only the status field is written** — the rest of the document belongs to the customer's app, and a full `set` from here would overwrite fields this build may not know about.

"Encaissé" sits in the per-customer detail of the preparation screen, where the shop already looks while assembling a market batch, and only on the orders that carry it. The update is optimistic and reverts on failure: the owner is standing in front of the customer and should not wait on a round-trip.

## Two refusals are the point of this lot

- **An ONLINE order can never be marked paid by hand.** Settling one that way would paper over whatever went wrong in the payment chain instead of surfacing it.
- **The J+3 write-off touches ON_SITE orders only.** An online order stuck in `PENDING` may mean the customer was charged and finalization failed; cancelling it automatically would erase the only trace of that. An unreadable delivery date is likewise left alone rather than guessed at.

## One open decision, decided provisionally

The sweep runs **from the admin app when the order list loads**, not from a scheduled Cloud Function — the mechanism the spec left open (§11.1). It therefore only runs when you open that screen, which is enough for a write-off with no deadline of its own. Moving it server-side remains a decision, not an oversight; say the word and I'll do it.

## Verification

- Both flavors compile.
- 8 new unit tests: both refusals, the grace boundary either side, an already-settled order, an unreadable date, and a failed write not being reported as a cancellation.
- Full suite at the documented baseline — the same 2 `AdminViewModelTest` failures, no new ones.
- No Firestore write, no device available, and **no real payment was ever attempted**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)