### PR TITLE
No invoice for money taken outside the app

### DIFF
--- a/admin/domain/src/main/java/com/mtdevelopment/admin/domain/usecase/OnSitePaymentUseCases.kt
+++ b/admin/domain/src/main/java/com/mtdevelopment/admin/domain/usecase/OnSitePaymentUseCases.kt
@@ -35,6 +35,14 @@ const val ON_SITE_ORDER_GRACE_DAYS = 3L
  *
  * Resolving it means a payment state of its own (a `paid_at`, or a status on [PaymentMode]),
  * which changes the Firestore schema and is a decision for the shop, not for this use case.
+ *
+ * **This write is watched by the backend.** `onOrderPaidCreateInvoice` fires on every
+ * transition to [OrderStatus.PAID] and used to email an Invoice Ninja invoice — so pressing
+ * "encaissé" at the counter sent the customer a bill for money they had just handed over in
+ * person. Since 2026-08-19 `createAndSendInvoice` skips anything whose `payment_mode` is
+ * [PaymentMode.ON_SITE], by the shop's decision: no invoice at all for money taken outside
+ * the app. Nothing to do here, but anyone changing which status this writes, or introducing
+ * the dedicated payment state described above, has to look at that function too.
  */
 class MarkOrderPaidOnSiteUseCase(
     private val firebaseAdminRepository: FirebaseAdminRepository

--- a/la-fromagerie-backend/functions/src/billing.ts
+++ b/la-fromagerie-backend/functions/src/billing.ts
@@ -4,12 +4,15 @@ import { InvoiceLine, InvoiceNinjaClient, describeError } from "./invoiceNinja.j
 /**
  * Logique de facturation partagée entre les deux déclencheurs :
  *  - handleSumUpWebhook (chemin hosted-checkout, vérifié côté SumUp) ;
- *  - onOrderPaidCreateInvoice (trigger Firestore, couvre TOUS les chemins de
- *    paiement dès que la commande passe à PAID).
+ *  - onOrderPaidCreateInvoice (trigger Firestore, sur toute transition vers
+ *    PAID, quel que soit le chemin de paiement).
  *
  * Idempotent : chaque commande est facturée une seule fois, via une
  * réclamation transactionnelle dans la collection `invoices`. Les deux
  * déclencheurs peuvent donc coexister sans risque de double facture.
+ *
+ * Une seule exception, décidée par la boutique le 2026-08-19 : une commande
+ * réglée hors application n'est pas facturée du tout (voir ON_SITE plus bas).
  */
 
 export type InvoiceResult =
@@ -30,6 +33,12 @@ export interface InvoiceOptions {
  *
  * En cas de panne transitoire (Invoice Ninja injoignable…), la réclamation est
  * relâchée et le statut `failed` est renvoyé pour que l'appelant relance.
+ *
+ * Le garde-fou ON_SITE vit ICI et pas dans les déclencheurs : les deux passent
+ * par cette fonction, donc une règle unique les couvre tous les deux et il n'y
+ * a pas de version divergente à maintenir. Il renvoie `skipped` et jamais
+ * `failed` — le trigger Firestore tourne en `retry: true` et rejouerait
+ * indéfiniment une décision qui ne changera pas.
  */
 export async function createAndSendInvoice(
     orderId: string,
@@ -46,6 +55,24 @@ export async function createAndSendInvoice(
         if (!orderSnap.exists) {
             await releaseClaim(orderId);
             return { status: "skipped", reason: "commande introuvable" };
+        }
+
+        // Paiement hors application : la boutique encaisse au comptoir et ne veut
+        // aucune facture émise. Testé AVANT les validations de montant et d'email
+        // parce que la décision n'en dépend pas : une commande ON_SITE sans email
+        // serait autrement classée « email client manquant », ce qui décrirait un
+        // incident là où il n'y en a pas.
+        //
+        // Le critère est le mode de PAIEMENT, pas le mode de retrait : un client
+        // qui réserve en click & collect mais règle dans l'application reçoit sa
+        // facture comme n'importe quelle commande en ligne.
+        //
+        // La commande passe quand même à PAID — c'est ce que fait
+        // MarkOrderPaidOnSiteUseCase quand la boutique encaisse — donc ce
+        // déclenchement-ci est normal et attendu, pas une anomalie.
+        if (orderSnap.get("payment_mode") === "ON_SITE") {
+            await releaseClaim(orderId);
+            return { status: "skipped", reason: "réglée hors application (ON_SITE)" };
         }
 
         const orderTotalCents = orderSnap.get("total_price");


### PR DESCRIPTION
Pressing **« encaissé »** on an order paid at collection emailed the customer an Invoice Ninja
invoice for cash they had just handed over in person. One commit, five lines of guard, and the
coupling written down at both ends.

## Why it happened

Neither half was wrong on its own.

`MarkOrderPaidOnSiteUseCase` records payment by writing `OrderStatus.PAID`, because PAID is the
only place this schema has to say "the money is in" — a limitation the use case already
documents. `onOrderPaidCreateInvoice` fires on **every** transition to PAID, deliberately, so
that a payment path added later cannot quietly escape invoicing.

The two were written for different reasons, months apart, and neither mentions the other. That
is how the shop counter ended up wired to the invoice sender.

## The change

`createAndSendInvoice` returns `skipped` for any order whose `payment_mode` is `ON_SITE`. The
shop's decision, 2026-08-19: no invoice at all for money taken outside the app.

Three things about where and how:

- **The guard is in `createAndSendInvoice`, not in the triggers.** Both the Firestore trigger and
  the SumUp webhook go through it, so one rule covers both and there is no second copy to drift.
  The webhook cannot carry an `ON_SITE` order today — there is no SumUp checkout for one — but a
  rule that holds for a path that cannot happen costs nothing and stops being a question later.
- **It returns `skipped`, never `failed`.** The trigger runs `retry: true` and throws on `failed`,
  so classifying this as a failure would replay a decision that is never going to change.
- **It is tested before the amount and email validations**, which it does not depend on. An
  `ON_SITE` order with no email address would otherwise be reported as `email client manquant`,
  describing an incident where there is none.

The criterion is the **payment** mode, not the fulfillment mode: a customer who reserves for
collection but pays in the app still gets an invoice like any other online order.

## What is not covered

No automated test. The `functions` package has no test harness at all — no runner, no `test`
script, and the `firebase-functions-test` devDependency is unused. Standing one up is its own
piece of work, not a rider on a five-line guard. `tsc` compiles and both Android flavors compile.

**The real check is one collection paid at the counter after deploy:** no mail sent, and
`Commande … non facturée (trigger Firestore) : réglée hors application (ON_SITE).` in the
function logs.

## Deploy

Not deployed. `firebase deploy --only functions` is a production action and is the owner's call,
like the Firestore rules in #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
