### PR TITLE
Offer payment on collection at the shop counter only

### DIFF
--- a/admin/domain/src/main/java/com/mtdevelopment/admin/domain/usecase/OnSitePaymentUseCases.kt
+++ b/admin/domain/src/main/java/com/mtdevelopment/admin/domain/usecase/OnSitePaymentUseCases.kt
@@ -17,6 +17,13 @@ const val ON_SITE_ORDER_GRACE_DAYS = 3L
  * a manual "encaissé" on one would paper over whatever went wrong there instead of
  * surfacing it.
  *
+ * Reads [PaymentMode] alone, and deliberately ignores [Order.fulfillmentType] even though the
+ * client can no longer place an ON_SITE order anywhere but the shop (2026-08-20). The rule
+ * belongs to the checkout, where an order is written; this use case only records that money
+ * arrived. Adding the collection mode here would leave any ON_SITE order that is not a shop
+ * collection — written by a build predating the rule, or by a hand — with no way to be cashed
+ * at all, which is a worse outcome than an order that breaks the rule.
+ *
  * ⚠️ **Known coupling, not yet resolved: this writes payment into the lifecycle field.**
  * "Encaissé" is a fact about money, and the only place it is recorded is
  * [OrderStatus.PAID] — the same field that also says where an order is in its life. Lot 1

--- a/checkout/presentation/src/main/java/com/mtdevelopment/checkout/presentation/screen/CheckoutScreen.kt
+++ b/checkout/presentation/src/main/java/com/mtdevelopment/checkout/presentation/screen/CheckoutScreen.kt
@@ -61,6 +61,7 @@ import com.mtdevelopment.checkout.presentation.BuildConfig
 import com.mtdevelopment.checkout.presentation.composable.UserInfoFormComposable
 import com.mtdevelopment.checkout.presentation.viewmodel.CheckoutViewModel
 import com.mtdevelopment.core.domain.toStringPrice
+import com.mtdevelopment.core.model.FulfillmentType
 import com.mtdevelopment.core.presentation.MainViewModel
 import com.mtdevelopment.core.presentation.composable.ErrorOverlay
 import com.mtdevelopment.core.presentation.composable.PrimaryButton
@@ -482,11 +483,12 @@ fun CheckoutScreen(
             )
 
             /**
-             * Pay on collection. Offered only for a collected order: there is nobody to hand
-             * cash to on a delivery round, and offering it there would create orders the shop
-             * can never settle.
+             * Pay on collection. Offered for a collection at the shop and nowhere else: the
+             * shop takes money over its own counter, not on a market stall and not on a
+             * delivery round. Anywhere else the button would create an order nobody can
+             * settle.
              */
-            if (uiData.value.fulfillmentType.isPickup) {
+            if (uiData.value.fulfillmentType == FulfillmentType.PICKUP_SHOP) {
                 PrimaryButton(
                     modifier = Modifier
                         .testTag("payOnSiteButton")

--- a/checkout/presentation/src/main/java/com/mtdevelopment/checkout/presentation/viewmodel/CheckoutViewModel.kt
+++ b/checkout/presentation/src/main/java/com/mtdevelopment/checkout/presentation/viewmodel/CheckoutViewModel.kt
@@ -503,8 +503,8 @@ class CheckoutViewModel(
                         totalPrice = _paymentScreenState.value.totalPrice,
                         // The pickup point is snapshotted onto the order, not referenced:
                         // editing or deleting that point later must not rewrite this
-                        // purchase. Payment stays ONLINE here — paying on collection is a
-                        // separate chain that does not exist yet.
+                        // purchase. The payment mode is the caller's to state: ONLINE by
+                        // default, ON_SITE only from placeOrderToPayOnSite.
                         fulfillmentType = _paymentScreenState.value.fulfillmentType,
                         paymentMode = paymentMode,
                         customerPhone = _paymentScreenState.value.buyerPhone,
@@ -534,8 +534,20 @@ class CheckoutViewModel(
      * connection would mint a fresh order id and place a second ON_SITE order that no
      * reconciliation chain would ever catch. The loading flag is both that guard and the
      * customer's feedback, so it has to be released on every way out.
+     *
+     * Restricted to [FulfillmentType.PICKUP_SHOP], and this is the only place that writes
+     * [PaymentMode.ON_SITE]: the shop takes money over its own counter and nowhere else.
+     * `CheckoutScreen` already hides the button for the other two modes, so the check below
+     * is not what enforces the rule day to day — it catches the tap that was already in
+     * flight when the mode changed underneath the screen, which the live datastore collect in
+     * [updateUiState] makes possible. Nothing is reported when it fires: the customer watched
+     * the button disappear, and an order that was never written is not an incident.
      */
     fun placeOrderToPayOnSite(onResult: (Boolean) -> Unit) {
+        if (_paymentScreenState.value.fulfillmentType != FulfillmentType.PICKUP_SHOP) {
+            onResult.invoke(false)
+            return
+        }
         if (_paymentScreenState.value.isLoading) return
         _paymentScreenState.update { it.copy(isLoading = true) }
 

--- a/checkout/presentation/src/test/java/com/mtdevelopment/checkout/presentation/viewmodel/CheckoutViewModelTest.kt
+++ b/checkout/presentation/src/test/java/com/mtdevelopment/checkout/presentation/viewmodel/CheckoutViewModelTest.kt
@@ -582,7 +582,12 @@ class CheckoutViewModelTest {
         assertEquals("La Fromagerie", placedOrder.captured.pickupLabel)
     }
 
-    /** Delivery is untouched: the address it was given is the address it carries. */
+    /**
+     * Delivery is untouched: the address it was given is the address it carries.
+     *
+     * Placed through [CheckoutViewModel.createOrder] rather than the on-site entry point,
+     * which now refuses anything that is not a shop collection.
+     */
     @Test
     fun `a delivered order still carries the customer address`() = runTest(testDispatcher) {
         seedCheckoutData(FulfillmentType.DELIVERY)
@@ -594,16 +599,45 @@ class CheckoutViewModelTest {
         viewModel.updateUiState()
         testScheduler.advanceUntilIdle()
 
-        viewModel.placeOrderToPayOnSite { }
+        viewModel.createOrder { }
         testScheduler.advanceUntilIdle()
 
         assertEquals("1 rue du Fromage", placedOrder.captured.customerAddress)
     }
 
+    /**
+     * Paying at collection is the shop's counter and nowhere else. The button is hidden on a
+     * market, so reaching this at all means the mode changed under the screen with a tap
+     * already in flight — and the order that tap would have written is exactly the one the
+     * shop no longer accepts.
+     */
+    @Test
+    fun `placeOrderToPayOnSite refuses a market collection`() = runTest(testDispatcher) {
+        seedCheckoutData(FulfillmentType.PICKUP_MARKET)
+
+        val viewModel = buildViewModel()
+        testScheduler.advanceUntilIdle()
+        viewModel.updateUiState()
+        testScheduler.advanceUntilIdle()
+
+        var result: Boolean? = null
+        viewModel.placeOrderToPayOnSite { result = it }
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(false, result)
+        coVerify(exactly = 0) { createNewOrderUseCase.invoke(any()) }
+        // Nothing was started, so nothing may be left behind: no cart cleared, no reminder
+        // scheduled, and above all no success the customer could read as an order placed.
+        coVerify(exactly = 0) { clearCartUseCase.invoke() }
+        coVerify(exactly = 0) { scheduleOrderReminderUseCase.invoke(any()) }
+        assertFalse(viewModel.paymentScreenState.value.isPaymentSuccess)
+        assertFalse(viewModel.paymentScreenState.value.isLoading)
+    }
+
     @Test
     fun `placeOrderToPayOnSite creates a single order when tapped twice in a row`() =
         runTest(testDispatcher) {
-            seedCheckoutData()
+            seedCheckoutData(FulfillmentType.PICKUP_SHOP)
             val placedOrder = slot<Order>()
             coEvery { createNewOrderUseCase.invoke(capture(placedOrder)) } returns true
 
@@ -627,7 +661,7 @@ class CheckoutViewModelTest {
     @Test
     fun `placeOrderToPayOnSite releases the loading flag when the order cannot be created`() =
         runTest(testDispatcher) {
-            seedCheckoutData()
+            seedCheckoutData(FulfillmentType.PICKUP_SHOP)
             coEvery { createNewOrderUseCase.invoke(any()) } returns false
 
             val viewModel = buildViewModel()
@@ -649,7 +683,7 @@ class CheckoutViewModelTest {
     @Test
     fun `placeOrderToPayOnSite still confirms the order when the reminder cannot be scheduled`() =
         runTest(testDispatcher) {
-            seedCheckoutData()
+            seedCheckoutData(FulfillmentType.PICKUP_SHOP)
             coEvery { createNewOrderUseCase.invoke(any()) } returns true
             coEvery { scheduleOrderReminderUseCase.invoke(any()) } throws
                     IllegalStateException("WorkManager unavailable")

--- a/core/domain/src/main/java/com/mtdevelopment/core/model/PaymentMode.kt
+++ b/core/domain/src/main/java/com/mtdevelopment/core/model/PaymentMode.kt
@@ -18,7 +18,15 @@ enum class PaymentMode {
     /** Paid in the app through Google Pay / SumUp before the order is honoured. */
     ONLINE,
 
-    /** Paid to the shop when the order is collected. */
+    /**
+     * Paid to the shop when the order is collected.
+     *
+     * Only ever written on a [FulfillmentType.PICKUP_SHOP] order, by the shop's decision of
+     * 2026-08-20: money is taken over the counter, not on a market stall. `CheckoutViewModel`
+     * is the single writer and holds the check; nothing here enforces it, because a reader —
+     * the admin app above all — must still be able to make sense of any ON_SITE order it
+     * finds, whatever its collection mode.
+     */
     ON_SITE;
 
     companion object {

--- a/docs/spec-retrait-click-and-collect.md
+++ b/docs/spec-retrait-click-and-collect.md
@@ -18,7 +18,8 @@ La livraison à domicile existante n'est pas modifiée dans son fonctionnement.
 
 ### Dans le périmètre v1
 
-Les trois modes de retrait ; le paiement en ligne **ou** sur place ; la tarification différenciée
+Les trois modes de retrait ; le paiement en ligne **ou** sur place (boutique uniquement,
+voir §3.4) ; la tarification différenciée
 par mode ; la gestion des jours de fermeture ; les rappels le jour J (retrait **et** livraison) ;
 les adaptations admin indispensables à la sécurité opérationnelle.
 
@@ -77,7 +78,21 @@ En mode retrait, l'écran de livraison actuel est réduit :
 ### 3.4 Paiement
 
 Le client choisit entre **payer en ligne** (Google Pay → SumUp, chaîne strictement inchangée) et
-**payer sur place** au moment du retrait. Le mode de paiement est indépendant du mode de retrait.
+**payer sur place** au moment du retrait.
+
+⚠️ **Règle modifiée le 20/08/2026 : le paiement sur place n'est offert qu'en retrait boutique.**
+La v1 les avait déclarés indépendants ; ils ne le sont plus. Un retrait sur marché, comme une
+livraison, se paie en ligne — la boutique encaisse à son comptoir et nulle part ailleurs.
+
+Concrètement : `payment_mode = ON_SITE` **implique** `fulfillment_type = PICKUP_SHOP`. La règle
+est portée par les deux champs existants, aucun champ n'est ajouté. Elle est tenue à deux endroits
+et pas un de plus — `CheckoutScreen` n'affiche le bouton qu'en boutique, et
+`CheckoutViewModel.placeOrderToPayOnSite`, seul écrivain de `ON_SITE`, refuse tout autre mode
+(le clic déjà parti quand le mode change sous l'écran). Rien n'est dit au client en retrait
+marché : le bouton est simplement absent, décision du 20/08/2026.
+
+Côté admin, rien n'est restreint : l'encaissement et l'annulation J+3 continuent de ne lire que
+`payment_mode`, sans regarder le mode de retrait (voir §6.2 et §6.3).
 
 ---
 
@@ -227,7 +242,7 @@ lancement sans réseau (corrigé le 29/07 sur les parcours).
 | Commande créée, paiement en ligne en cours | `PENDING` | `ONLINE` |
 | Paiement en ligne réussi | `PAID` | `ONLINE` |
 | Paiement en ligne échoué | `CANCELED` | `ONLINE` |
-| Commande à payer sur place | `PENDING` | `ON_SITE` |
+| Commande à payer sur place (retrait boutique **uniquement**, §3.4) | `PENDING` | `ON_SITE` |
 | Encaissée par l'admin au retrait | `PAID` | `ON_SITE` |
 
 Le champ `payment_mode` est ce qui **désambiguïse `PENDING`**, aujourd'hui porteur de deux sens
@@ -240,6 +255,11 @@ retomberait dans la confusion qu'on cherche à lever. Un champ inconnu, lui, est
 
 Action admin « Encaissé » sur la commande → passage en `PAID`. **Aucune facture n'est émise** pour
 ce chemin : le flux Invoice Ninja reste réservé aux paiements en ligne.
+
+L'action ne lit que `payment_mode`, jamais `fulfillment_type`, et cela reste vrai après la règle
+du 20/08/2026. L'admin lit ce qui a été écrit, il n'applique pas la règle : une commande `ON_SITE`
+qui ne serait pas en boutique doit rester encaissable, sans quoi l'argent qu'elle représente
+n'aurait plus aucun écran pour être enregistré.
 
 ### 6.3 Annulation automatique des commandes non retirées
 
@@ -347,11 +367,14 @@ l'admin sache la distinguer d'une livraison.
 6. Modifier ou supprimer un point de retrait ne modifie aucune commande existante.
 7. Une commande `ON_SITE` non retirée passe en `CANCELED` à J+3 ; une commande `ONLINE` en
    `PENDING` n'est **jamais** annulée automatiquement.
-8. Sans réseau au premier lancement, l'absence de points de retrait est signalée comme une erreur,
+8. Depuis le 20/08/2026, aucune commande `ON_SITE` ne peut être créée hors
+   `fulfillment_type = PICKUP_SHOP` ; l'encaissement admin, lui, reste possible sur toute
+   commande `ON_SITE` quel que soit son mode de retrait.
+9. Sans réseau au premier lancement, l'absence de points de retrait est signalée comme une erreur,
    jamais présentée comme « aucun retrait possible ».
-9. Le rappel jour J se déclenche pour une commande en livraison comme pour une commande en retrait,
-   et survit à un redémarrage de l'appareil.
-10. Les deux flavors compilent, et la suite de tests ne régresse pas au-delà des 2 échecs connus
+10. Le rappel jour J se déclenche pour une commande en livraison comme pour une commande en retrait,
+    et survit à un redémarrage de l'appareil.
+11. Les deux flavors compilent, et la suite de tests ne régresse pas au-delà des 2 échecs connus
     d'`AdminViewModelTest`.
 
 ---
@@ -362,7 +385,11 @@ l'admin sache la distinguer d'une livraison.
 2. **Fermer une date sur laquelle des commandes existent déjà** — refuser, ou avertir et laisser
    faire en listant les clients à prévenir ?
 3. **Adresse de facturation en retrait avec paiement sur place** — aucune adresse n'est alors
-   collectée. Acceptable puisqu'aucune facture n'est émise, à confirmer.
+   collectée. Acceptable puisqu'aucune facture n'est émise, à confirmer. Depuis le 20/08/2026 la
+   question ne porte plus que sur le retrait boutique. Elle en soulève en revanche une autre :
+   un retrait marché se paie désormais toujours en ligne, donc **est toujours facturé**, avec une
+   commande qui ne porte ni `customer_address` ni, souvent, `billing_address`
+   (`billing.ts:81` retombe alors sur une chaîne vide). Défaut préexistant, fréquence accrue.
 
 Aucune de ces trois questions ne bloque le démarrage : les lots 0 à 4 peuvent être menés sans y
 répondre, seul le lot 5 attend la réponse à la n°1.


### PR DESCRIPTION
## What changed

**1. The button is shop-only** (`CheckoutScreen.kt`)
"Payer sur place au retrait" was shown for `fulfillmentType.isPickup`, so markets included. It is now gated on `FulfillmentType.PICKUP_SHOP`. Nothing is said to a market customer — by decision, the button is simply absent, and no copy was added anywhere in the funnel.

**2. The rule is held in the ViewModel too** (`CheckoutViewModel.kt`)
`placeOrderToPayOnSite` is the only place that ever writes `PaymentMode.ON_SITE`, and it wrote it on whatever `fulfillmentType` the state happened to carry. It now refuses anything that is not `PICKUP_SHOP`, before the loading flag is even set. This is not what enforces the rule day to day — the button is already gone — it catches the tap that was already in flight when the mode changed underneath the screen, which the live datastore collect in `updateUiState` makes possible. Nothing is reported when it fires: the customer watched the button disappear, and an order that was never written is not an incident.

**3. The admin side is deliberately unchanged** (`OnSitePaymentUseCases.kt`, KDoc only)
`MarkOrderPaidOnSiteUseCase` and `CancelStaleOnSiteOrdersUseCase` still read `payment_mode` alone and ignore `fulfillment_type`. The reasoning is now written down where someone would otherwise "tidy" it: the rule belongs to the checkout, where an order is written, while "encaissé" only records that money arrived. Narrowing the condition would leave any `ON_SITE` order that is not a shop collection — written by a build predating the rule, or by hand — with no screen left to take its money, which is worse than an order that breaks the rule.

**4. The invariant is documented where it is read** (`PaymentMode.kt`)
`ON_SITE` now states that it is only ever written on a `PICKUP_SHOP` order, who holds the check, and why no reader enforces it.

**5. Tests** (`CheckoutViewModelTest.kt`)
Three on-site tests were seeded as deliveries while calling the on-site path, which the guard now rejects — they seed `PICKUP_SHOP`. `a delivered order still carries the customer address` was borrowing `placeOrderToPayOnSite` to reach `createOrder`; it calls `createOrder` directly, which is what it was ever really testing. New: `placeOrderToPayOnSite refuses a market collection`, asserting the refusal *and* the absence of side effects — no order, no cart cleared, no reminder scheduled, no `isPaymentSuccess`.

**6. Spec** (`docs/spec-retrait-click-and-collect.md`)
§3.4 stated the opposite ("Le mode de paiement est indépendant du mode de retrait"). Rewritten and dated, with §1, §6.1, §6.2, a new acceptance criterion 8, and §11.3.

## Why

Shop decision of 2026-08-20: payment on collection is offered at the shop and no longer on a market date. `payment_mode = ON_SITE` now implies `fulfillment_type = PICKUP_SHOP`. No schema change — the rule rides on the two fields that already exist.

Firestore rules were left alone on purpose. A rule rejecting the combination would be the strongest verrou, but it also breaks checkout for any installed APK that can still write it; 1.1.0 (versionCode 31, the click & collect release) is not published yet, so no such order can exist today and the app-side guard is enough. Worth revisiting only if the combination ever needs to be impossible rather than merely unwritten.

## Verification

No device testing — this change has no runtime surface beyond a button that disappears, and the payment chain itself is untouched.

- `:checkout:presentation:testClientDebugUnitTest` — `CheckoutViewModelTest` 23 tests, 0 failures, including the new market refusal.
- `./gradlew testClientDebugUnitTest --continue` and `testAdminDebugUnitTest --continue` — both stop on exactly the 2 documented `AdminViewModelTest` failures (`addNewProduct` / `updateProduct` aborts when local image upload fails), none added.
- `:app:compileClientDebugKotlin` and `:app:compileAdminDebugKotlin` — both flavors compile.
- Untested by design: the guard's race (mode change with a tap in flight) is covered by unit test, not on device — it cannot be produced by hand reliably.

## Follow-ups, not in this PR

- An online-paid pickup order can reach Invoice Ninja with an empty client address (`billing.ts:81` uses `??`, which does not catch `""`). Pre-existing, but this change makes every market pickup an online payment, so every one of them now takes that path.
- `fromagerie-payments-reference` and `fromagerie-firestore-data-model` never mentioned `ON_SITE` at all — lot 5 was never folded into the skill library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
